### PR TITLE
Make “全部显示” restore the default resolver display

### DIFF
--- a/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
@@ -292,12 +292,16 @@ class ListCleanerModule : XposedModule() {
     private fun orderHooker() = XposedInterface.Hooker { chain ->
         pollPreferences()
         val replacement = runCatching {
+            val current = snapshot
+            if (current.displayMode == DisplayMode.SHOW_ALL) {
+                diagnostic("ORDER_SKIP reason=show_all")
+                return@runCatching null
+            }
             val receiver = chain.thisObject ?: return@runCatching null
             val kind = adapterKind(receiver) ?: run {
                 diagnostic("ORDER_SKIP reason=unclassified_intent")
                 return@runCatching null
             }
-            val current = snapshot
             val priorities = current.priorities.apps[kind].orEmpty()
             if (priorities.isEmpty()) {
                 diagnostic("ORDER_SKIP kind=$kind reason=no_priorities")
@@ -323,6 +327,10 @@ class ListCleanerModule : XposedModule() {
                 return@runCatching
             }
             pollPreferences()
+            if (snapshot.displayMode == DisplayMode.SHOW_ALL) {
+                diagnostic("ORDER_SKIP stage=alpha reason=show_all")
+                return@runCatching
+            }
             val kind = adapterKind(receiver) ?: return@runCatching
             val items = OrderingAccess.field(receiver, "mSortedList")
             if (items == null || items.javaClass != java.util.ArrayList::class.java) {
@@ -451,10 +459,12 @@ class ListCleanerModule : XposedModule() {
     private fun transform(kind: IntentKind, values: List<*>, layer: Layer, callerUid: Int): List<*>? {
         if (values.isEmpty()) { diagnostic("SKIP $layer $kind empty_input"); return null }
         val current = snapshot
+        if (current.displayMode == DisplayMode.SHOW_ALL) {
+            diagnostic("NO_CHANGE $layer $kind size=${values.size} reason=show_all")
+            return null
+        }
         var changed = false
-        val filtered = if (current.displayMode == DisplayMode.SHOW_ALL ||
-            (!current.hasSelection(kind) && current.displayMode != DisplayMode.SHOW_SELECTED)
-        ) {
+        val filtered = if (!current.hasSelection(kind) && current.displayMode != DisplayMode.SHOW_SELECTED) {
             values
         } else {
             values.filter { value ->


### PR DESCRIPTION
将状态页“全部显示”明确实现为全局暂停模式：

- 不执行规则过滤，直接保留 Android 原始候选结果
- 不执行模块的 Resolver 排序/文本处理排序，恢复系统默认显示
- 不修改规则页任何已选规则
- 不清空排序配置；切回“隐藏选中”或“只显示选中”后继续使用原配置

这使“全部显示”成为纯暂停开关，而不是清空配置。