### PR TITLE
Tighten release publishing triggers

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,14 +9,6 @@ on:
       - 'RELEASE_NOTES.md'
       - '.github/workflows/build-release.yml'
       - 'tools/prepare-release-signing.py'
-  push:
-    branches: [main]
-    paths:
-      - 'app/build.gradle.kts'
-      - 'RELEASE_NOTES.md'
-      - '.github/workflows/build-release.yml'
-      - 'tools/prepare-release-signing.py'
-      - 'signing/release-certificate.sha256'
 
 permissions:
   contents: read
@@ -67,7 +59,7 @@ jobs:
   release:
     permissions:
       contents: write
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     defaults:

--- a/.github/workflows/publish-telegram.yml
+++ b/.github/workflows/publish-telegram.yml
@@ -7,10 +7,8 @@ on:
         description: 'Source release tag (for example v1.6.5); empty means latest'
         required: false
         type: string
-  workflow_run:
-    workflows: ['Build and Publish Release']
-    types: [completed]
-    branches: [main]
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -23,11 +21,7 @@ jobs:
   publish:
     if: >-
       github.repository == 'yagay/ListCleaner' &&
-      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') &&
-      (github.event_name != 'workflow_run' ||
-       (github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.head_repository.full_name == github.repository &&
-        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch')))
+      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -51,5 +45,5 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: '@LISTCLEANER'
-          SOURCE_TAG: ${{ inputs.tag || '' }}
+          SOURCE_TAG: ${{ inputs.tag || github.event.release.tag_name || '' }}
         run: python3 tools/publish-telegram.py

--- a/.github/workflows/sync-lsposed.yml
+++ b/.github/workflows/sync-lsposed.yml
@@ -9,16 +9,6 @@ on:
         type: string
   release:
     types: [published]
-  workflow_run:
-    workflows: ['Build and Publish Release']
-    types: [completed]
-    branches: [main]
-  push:
-    branches: [main]
-    paths:
-      - '.github/workflows/sync-lsposed.yml'
-      - 'tools/sync-lsposed.py'
-      - 'docs/lsposed/**'
 
 permissions:
   contents: read
@@ -31,11 +21,7 @@ jobs:
   sync:
     if: >-
       github.repository == 'yagay/ListCleaner' &&
-      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') &&
-      (github.event_name != 'workflow_run' ||
-       (github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.head_repository.full_name == github.repository &&
-        (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'workflow_dispatch')))
+      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
调整发布链触发条件，避免普通源码修改或 Debug 测试误启动正式发布同步：

- `Build and Publish Release` 不再监听 `main` push；正式 Release 只允许在 `main` 手动 `workflow_dispatch`。
- PR 仍保留无签名 Release 编译验证，不会发布正式版本。
- `Sync LSPosed Release` 不再监听 Release workflow 完成或文档/脚本 push；仅在 GitHub Release 真正 `published` 后自动运行，或手动运行。
- `Publish Telegram Release` 改为仅在 GitHub Release 真正 `published` 后自动运行，或手动运行。
- Telegram 自动发布时明确使用本次 published Release 的 tag。

此 PR 不自动合并，等待测试/确认后再进入 `main`。