### PR TITLE
Expand typed OPEN rules, sorting and diagnostics

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -66,7 +66,6 @@ jobs:
           bash ./gradlew --no-daemon --console=plain --stacktrace :app:assembleDebug 2>&1 | tee debug-build.log
 
       - name: Upload Debug APK
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ListCleaner-debug-${{ github.run_number }}-${{ github.run_attempt }}

--- a/app/src/main/java/com/yagay/ListCleaner/ListCleanerApp.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ListCleanerApp.kt
@@ -23,6 +23,9 @@ data class RuntimeStatus(
     val message: String = "等待核实运行模块与配置",
     val digest: String = "",
     val recoveryCorrupt: Boolean = false,
+    val queryHits: Long = 0,
+    val visibilityHits: Long = 0,
+    val orderingHits: Long = 0,
     val observedAtMillis: Long = System.currentTimeMillis()
 )
 
@@ -97,15 +100,12 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                 }
                 pendingRecovery = null
                 corruptRecovery = false
-                // Never send a new schema to old code or accept a stale scan as a fresh catalog.
                 check(bound.apiVersion >= 102) { "框架需要 API 102；暂停同步和扫描" }
                 val targets = bound.runningTargets
                 val config = rules.remoteSnapshot()
                 val encoded = json.encodeToString(ModuleConfig.serializer(), config)
                 require(encoded.length <= RuleRepository.MAX_BACKUP_CHARS) { "配置超过传输上限，请减少规则后重试；未写入远程" }
                 val digest = RuntimeProtocol.digest(encoded)
-                // Only the known v1 JSON readers (19..24) may receive an Intent-filter pause
-                // before the strict scan/version gate. Never send new rules to stale code.
                 val canPause = config.mode == DisplayMode.SHOW_ALL && targets.isNotEmpty() && targets.all {
                     RuntimeProtocol.supportsSafetyPause(it.state.name, it.loadedVersionCode)
                 }
@@ -124,16 +124,27 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                 if (prefs.getString(RuleRepository.KEY_CONFIG, null) != encoded) {
                     check(prefs.edit().putString(RuleRepository.KEY_CONFIG, encoded).commit()) { "远程配置写入失败" }
                 }
-                // Read-back isn't hook acknowledgement. The private action is UID-authenticated
-                // in system_server and returns the digest of the actual applied snapshot.
+
                 var acknowledged = false
+                var queryHits = 0L
+                var visibilityHits = 0L
+                var orderingHits = 0L
                 repeat(4) {
                     if (!acknowledged) {
                         @Suppress("DEPRECATION")
                         val results = packageManager.queryIntentActivities(Intent(RuntimeProtocol.ACTION).setPackage(packageName), 0)
-                        acknowledged = results.any { info ->
+                        val prefix = "${BuildConfig.VERSION_CODE}:$digest"
+                        results.firstOrNull { info ->
                             info.activityInfo?.packageName == packageName && info.activityInfo?.name == RuntimeProtocol.COMPONENT &&
-                                info.nonLocalizedLabel?.toString() == "${BuildConfig.VERSION_CODE}:$digest"
+                                (info.nonLocalizedLabel?.toString() == prefix || info.nonLocalizedLabel?.toString()?.startsWith("$prefix:") == true)
+                        }?.let { info ->
+                            acknowledged = true
+                            val parts = info.nonLocalizedLabel?.toString().orEmpty().split(':')
+                            if (parts.size >= 5) {
+                                queryHits = parts[2].toLongOrNull() ?: 0L
+                                visibilityHits = parts[3].toLongOrNull() ?: 0L
+                                orderingHits = parts[4].toLongOrNull() ?: 0L
+                            }
                         }
                         if (!acknowledged) delay(150)
                     }
@@ -141,7 +152,14 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                 check(service.value === bound) { "连接已变化，请重试" }
                 check(acknowledged) { "配置已写入，但系统 Hook 未确认接收；暂停扫描，请重试或重启" }
                 check(rules.remoteSnapshot() == config) { "配置在确认期间发生变化，正在重新同步" }
-                publish(RuntimeStatus(ready = true, message = "系统 Hook 已确认配置和管理查询豁免；选择器效果仍需实际验证", digest = digest))
+                publish(RuntimeStatus(
+                    ready = true,
+                    message = "系统 Hook 已确认配置；可在状态页查看过滤、应用可见性和排序的实际命中次数",
+                    digest = digest,
+                    queryHits = queryHits,
+                    visibilityHits = visibilityHits,
+                    orderingHits = orderingHits
+                ))
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (failure: Exception) {

--- a/app/src/main/java/com/yagay/ListCleaner/ListCleanerApp.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ListCleanerApp.kt
@@ -8,6 +8,7 @@ import com.yagay.ListCleaner.domain.ModuleConfig
 import com.yagay.ListCleaner.domain.DisplayMode
 import com.yagay.ListCleaner.domain.PriorityConfig
 import com.yagay.ListCleaner.domain.RuntimeProtocol
+import com.yagay.ListCleaner.domain.deriveFullySelectedPackages
 import io.github.libxposed.service.XposedService
 import io.github.libxposed.service.XposedServiceHelper
 import kotlinx.coroutines.*
@@ -46,6 +47,11 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
         rules = RuleRepository(this)
         catalog = IntentCatalog(this)
         XposedServiceHelper.registerListener(this)
+        applicationScope.launch {
+            combine(rules.rules, catalog.candidates) { selected, candidates ->
+                deriveFullySelectedPackages(candidates, selected)
+            }.collect(rules::setVisibilityFullPackages)
+        }
         applicationScope.launch {
             combine(rules.revision, service) { _, _ -> Unit }.collect { synchronize() }
         }

--- a/app/src/main/java/com/yagay/ListCleaner/data/IntentCatalog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/IntentCatalog.kt
@@ -12,6 +12,8 @@ import com.yagay.ListCleaner.domain.ComponentCandidate
 import com.yagay.ListCleaner.domain.ComponentIdentity
 import com.yagay.ListCleaner.domain.ComponentRule
 import com.yagay.ListCleaner.domain.IntentKind
+import com.yagay.ListCleaner.domain.OpenPreset
+import com.yagay.ListCleaner.domain.CustomOpenDefinition
 import com.yagay.ListCleaner.domain.intentKind
 import com.yagay.ListCleaner.domain.FilterPolicy
 import kotlinx.coroutines.Dispatchers
@@ -45,11 +47,11 @@ class IntentCatalog(private val context: Context) {
     private data class Probe(val intent: Intent, val broad: Boolean, val label: String)
     private data class QueryResult(val candidates: List<ComponentCandidate>, val raw: Int, val flags: Int = 0)
 
-    suspend fun scan(): List<ComponentCandidate> = withContext(Dispatchers.IO) {
+    suspend fun scan(customDefinitions: Map<OpenPreset, CustomOpenDefinition> = emptyMap()): List<ComponentCandidate> = withContext(Dispatchers.IO) {
         appIconCache.evictAll()
         val found = mutableListOf<ComponentCandidate>()
         val known = mutableSetOf<String>()
-        val report = StringBuilder("startedAt=${Instant.now()}\nmanagerUid=${android.os.Process.myUid()}\n")
+        val report = StringBuilder("startedAt=${Instant.now()}\nmanagerUid=${android.os.Process.myUid()}\ncustomOpenTypes=${customDefinitions.size}\n")
         for (scheme in listOf("http", "https")) {
             val web = Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://example.com")).addCategory(Intent.CATEGORY_BROWSABLE)
             runCatching {
@@ -62,7 +64,7 @@ class IntentCatalog(private val context: Context) {
         }
         var failures = 0
         scanWarning = null
-        for (probe in probes()) {
+        for (probe in probes(customDefinitions)) {
             currentCoroutineContext().ensureActive()
             try {
                 val result = query(probe)
@@ -109,14 +111,11 @@ class IntentCatalog(private val context: Context) {
     private fun query(probe: Probe, discovery: Boolean = true): QueryResult {
         val kind = probe.intent.intentKind() ?: return QueryResult(emptyList(), 0)
         val flags = queryFlags(kind, discovery)
-        check(flags and (PackageManager.MATCH_DISABLED_COMPONENTS or
-            PackageManager.MATCH_DISABLED_UNTIL_USED_COMPONENTS) == 0)
+        check(flags and (PackageManager.MATCH_DISABLED_COMPONENTS or PackageManager.MATCH_DISABLED_UNTIL_USED_COMPONENTS) == 0)
         val raw = context.packageManager.queryIntentActivities(probe.intent, flags)
         val candidates = raw.mapNotNull { info ->
             val activity = info.activityInfo ?: return@mapNotNull null
-            val canonicalClass = ComponentIdentity.canonicalClassName(
-                activity.packageName, activity.name, activity.targetActivity
-            )
+            val canonicalClass = ComponentIdentity.canonicalClassName(activity.packageName, activity.name, activity.targetActivity)
             val rule = ComponentRule(kind, activity.packageName, canonicalClass)
             if (!rule.isValid()) return@mapNotNull null
             val managerUid = android.os.Process.myUid()
@@ -125,9 +124,7 @@ class IntentCatalog(private val context: Context) {
             val facts = buildList {
                 add("启用状态以系统查询为准；元数据 activityEnabled=${activity.enabled} appEnabled=${activity.applicationInfo?.enabled}")
                 add("exported=${activity.exported} targetUid=$targetUid managerUid=$managerUid")
-                if (activity.targetActivity?.isNotBlank() == true) {
-                    add("activityAlias=${activity.name} targetActivity=${activity.targetActivity} canonical=$canonicalClass")
-                }
+                if (activity.targetActivity?.isNotBlank() == true) add("activityAlias=${activity.name} targetActivity=${activity.targetActivity} canonical=$canonicalClass")
                 if (restricted) add("非公开的其他应用组件；不放入普通目录")
                 activity.permission?.takeIf { it.isNotBlank() }?.let { permission ->
                     val granted = runCatching { context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED }.getOrNull()
@@ -139,8 +136,7 @@ class IntentCatalog(private val context: Context) {
                 runCatching { activity.applicationInfo.loadLabel(context.packageManager).toString() }.getOrDefault(activity.packageName),
                 runCatching { info.loadLabel(context.packageManager).toString() }.getOrDefault(activity.name.substringAfterLast('.')),
                 loadAppIcon(activity.packageName) {
-                    runCatching { activity.applicationInfo.loadIcon(context.packageManager) }.getOrNull()
-                        ?: context.packageManager.defaultActivityIcon
+                    runCatching { activity.applicationInfo.loadIcon(context.packageManager) }.getOrNull() ?: context.packageManager.defaultActivityIcon
                 },
                 evidence = listOf(probe.label + " flags=0x${flags.toString(16)}") + facts,
                 restricted = restricted, broadMatch = probe.broad
@@ -151,12 +147,10 @@ class IntentCatalog(private val context: Context) {
 
     private fun loadAppIcon(packageName: String, loader: () -> Drawable): Bitmap? {
         appIconCache.get(packageName)?.let { return it }
-        return runCatching { loader().toBitmap(width = 96, height = 96) }.getOrNull()?.also {
-            appIconCache.put(packageName, it)
-        }
+        return runCatching { loader().toBitmap(width = 96, height = 96) }.getOrNull()?.also { appIconCache.put(packageName, it) }
     }
 
-    private fun probes(): List<Probe> = buildList {
+    private fun probes(customDefinitions: Map<OpenPreset, CustomOpenDefinition>): List<Probe> = buildList {
         for ((mime, file) in FILE_TYPES) {
             for (action in listOf(Intent.ACTION_SEND, Intent.ACTION_SEND_MULTIPLE)) {
                 add(Probe(Intent(action).setType(mime), false, "${action.substringAfterLast('.')} mime=$mime"))
@@ -167,24 +161,36 @@ class IntentCatalog(private val context: Context) {
                     "file" -> "file:///storage/emulated/0/Download/$file"
                     else -> "https://example.com/$file"
                 }
-                val intent = Intent(Intent.ACTION_VIEW).setDataAndType(Uri.parse(uri), mime)
-                add(Probe(intent, false, "VIEW scheme=$scheme mime=$mime sample=$file"))
+                add(Probe(Intent(Intent.ACTION_VIEW).setDataAndType(Uri.parse(uri), mime), false, "VIEW scheme=$scheme mime=$mime sample=$file"))
             }
         }
+
+        customDefinitions.toSortedMap(compareBy { it.ordinal }).forEach { (preset, definition) ->
+            val fallbackExt = definition.extensions.firstOrNull() ?: "custom"
+            definition.mimeTypes.take(24).forEachIndexed { index, mime ->
+                val sample = "custom-$index.$fallbackExt"
+                for (scheme in listOf("content", "file")) {
+                    val uri = if (scheme == "content") "content://com.yagay.ListCleaner.placeholder/$sample" else "file:///storage/emulated/0/Download/$sample"
+                    add(Probe(Intent(Intent.ACTION_VIEW).setDataAndType(Uri.parse(uri), mime), false,
+                        "CUSTOM preset=${preset.name} VIEW scheme=$scheme mime=$mime sample=$sample"))
+                }
+            }
+            definition.extensions.take(48).forEach { ext ->
+                val sample = "custom.$ext"
+                val uri = "content://com.yagay.ListCleaner.placeholder/$sample"
+                add(Probe(Intent(Intent.ACTION_VIEW).setDataAndType(Uri.parse(uri), "application/octet-stream"), false,
+                    "CUSTOM preset=${preset.name} VIEW scheme=content mime=application/octet-stream sample=$sample"))
+            }
+        }
+
         for (scheme in listOf("http", "https")) {
-            add(Probe(Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://example.com"))
-                .addCategory(Intent.CATEGORY_BROWSABLE), false, "网页 scheme=$scheme"))
+            add(Probe(Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://example.com")).addCategory(Intent.CATEGORY_BROWSABLE), false, "网页 scheme=$scheme"))
         }
         listOf(
             "magnet" to "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567",
-            "geo" to "geo:0,0?q=London",
-            "mailto" to "mailto:test@example.com",
-            "tel" to "tel:123456789",
-            "sms" to "sms:123456789",
-            "smsto" to "smsto:123456789"
-        ).forEach { (scheme, value) ->
-            add(Probe(Intent(Intent.ACTION_VIEW, Uri.parse(value)), false, "VIEW scheme=$scheme"))
-        }
+            "geo" to "geo:0,0?q=London", "mailto" to "mailto:test@example.com", "tel" to "tel:123456789",
+            "sms" to "sms:123456789", "smsto" to "smsto:123456789"
+        ).forEach { (scheme, value) -> add(Probe(Intent(Intent.ACTION_VIEW, Uri.parse(value)), false, "VIEW scheme=$scheme")) }
         add(Probe(Intent(Intent.ACTION_PROCESS_TEXT).setType("text/plain"), false, "PROCESS_TEXT mime=text/plain"))
         for (mime in listOf("*/*", "image/*", "video/*", "audio/*")) {
             for (action in listOf(Intent.ACTION_SEND, Intent.ACTION_SEND_MULTIPLE)) {
@@ -192,24 +198,20 @@ class IntentCatalog(private val context: Context) {
             }
             for (scheme in listOf("content", "file")) {
                 val uri = if (scheme == "content") "content://com.yagay.ListCleaner.placeholder/item" else "file:///item"
-                add(Probe(Intent(Intent.ACTION_VIEW).setDataAndType(Uri.parse(uri), mime), true,
-                    "宽泛 VIEW scheme=$scheme mime=$mime"))
+                add(Probe(Intent(Intent.ACTION_VIEW).setDataAndType(Uri.parse(uri), mime), true, "宽泛 VIEW scheme=$scheme mime=$mime"))
             }
         }
     }
 
     companion object {
         fun queryFlags(kind: IntentKind, discovery: Boolean): Int =
-            (if (discovery) PackageManager.MATCH_ALL else 0) or
-                (if (kind == IntentKind.PROCESS_TEXT) 0 else PackageManager.MATCH_DEFAULT_ONLY)
+            (if (discovery) PackageManager.MATCH_ALL else 0) or (if (kind == IntentKind.PROCESS_TEXT) 0 else PackageManager.MATCH_DEFAULT_ONLY)
 
         fun merge(items: List<ComponentCandidate>): List<ComponentCandidate> =
             items.groupBy { it.rule.id }.values.map { matches ->
                 val first = matches.firstOrNull { it.isCatalogCandidate } ?: matches.first()
-                first.copy(evidence = matches.flatMap { it.evidence }.distinct()
-                    .sortedBy { !it.startsWith("实际文件检查") }.take(32),
-                    restricted = matches.all { it.restricted }, unavailable = matches.all { it.unavailable },
-                    broadMatch = matches.all { it.broadMatch })
+                first.copy(evidence = matches.flatMap { it.evidence }.distinct().sortedBy { !it.startsWith("实际文件检查") }.take(32),
+                    restricted = matches.all { it.restricted }, unavailable = matches.all { it.unavailable }, broadMatch = matches.all { it.broadMatch })
             }.sortedWith(compareBy({ it.rule.kind.ordinal }, { it.appLabel.lowercase() }, { it.rule.id }))
 
         private val FILE_TYPES = listOf(
@@ -222,11 +224,9 @@ class IntentCatalog(private val context: Context) {
             "application/msword" to "sample.doc",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document" to "sample.docx",
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" to "sample.xlsx",
-            "application/vnd.ms-excel" to "sample.xls",
-            "application/vnd.ms-powerpoint" to "sample.ppt",
+            "application/vnd.ms-excel" to "sample.xls", "application/vnd.ms-powerpoint" to "sample.ppt",
             "application/vnd.openxmlformats-officedocument.presentationml.presentation" to "sample.pptx",
-            "application/x-bittorrent" to "sample.torrent",
-            "text/markdown" to "sample.md", "text/csv" to "sample.csv",
+            "application/x-bittorrent" to "sample.torrent", "text/markdown" to "sample.md", "text/csv" to "sample.csv",
             "application/xml" to "sample.xml", "image/svg+xml" to "sample.svg", "image/gif" to "sample.gif",
             "application/x-7z-compressed" to "sample.7z", "application/vnd.rar" to "sample.rar"
         )

--- a/app/src/main/java/com/yagay/ListCleaner/data/IntentCatalog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/IntentCatalog.kt
@@ -175,6 +175,16 @@ class IntentCatalog(private val context: Context) {
             add(Probe(Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://example.com"))
                 .addCategory(Intent.CATEGORY_BROWSABLE), false, "网页 scheme=$scheme"))
         }
+        listOf(
+            "magnet" to "magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567",
+            "geo" to "geo:0,0?q=London",
+            "mailto" to "mailto:test@example.com",
+            "tel" to "tel:123456789",
+            "sms" to "sms:123456789",
+            "smsto" to "smsto:123456789"
+        ).forEach { (scheme, value) ->
+            add(Probe(Intent(Intent.ACTION_VIEW, Uri.parse(value)), false, "VIEW scheme=$scheme"))
+        }
         add(Probe(Intent(Intent.ACTION_PROCESS_TEXT).setType("text/plain"), false, "PROCESS_TEXT mime=text/plain"))
         for (mime in listOf("*/*", "image/*", "video/*", "audio/*")) {
             for (action in listOf(Intent.ACTION_SEND, Intent.ACTION_SEND_MULTIPLE)) {
@@ -211,7 +221,14 @@ class IntentCatalog(private val context: Context) {
             "application/vnd.android.package-archive" to "sample.apk",
             "application/msword" to "sample.doc",
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document" to "sample.docx",
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" to "sample.xlsx"
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" to "sample.xlsx",
+            "application/vnd.ms-excel" to "sample.xls",
+            "application/vnd.ms-powerpoint" to "sample.ppt",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation" to "sample.pptx",
+            "application/x-bittorrent" to "sample.torrent",
+            "text/markdown" to "sample.md", "text/csv" to "sample.csv",
+            "application/xml" to "sample.xml", "image/svg+xml" to "sample.svg", "image/gif" to "sample.gif",
+            "application/x-7z-compressed" to "sample.7z", "application/vnd.rar" to "sample.rar"
         )
     }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/data/IntentCatalog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/IntentCatalog.kt
@@ -19,11 +19,17 @@ import com.yagay.ListCleaner.domain.FilterPolicy
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.withContext
 import java.time.Instant
 
 /** Evidence-based discovery, not a claim to enumerate every installed intent filter. */
 class IntentCatalog(private val context: Context) {
+    private val mutableCandidates = MutableStateFlow<List<ComponentCandidate>>(emptyList())
+    val candidates: StateFlow<List<ComponentCandidate>> = mutableCandidates.asStateFlow()
+
     suspend fun completeConfigured(items: List<ComponentCandidate>, selected: Set<ComponentRule>): List<ComponentCandidate> = withContext(Dispatchers.IO) {
         val known = items.map { it.rule.id }.toSet()
         items + selected.filter { it.id !in known }.map { rule ->
@@ -82,6 +88,7 @@ class IntentCatalog(private val context: Context) {
         report.appendLine("finishedAt=${Instant.now()} unique=${result.size} failures=$failures")
         lastReport = report.toString()
         if (failures > 0) scanWarning = "部分扫描失败（$failures 项）；成功结果已更新，未匹配的已配置项可在“已选规则”中管理"
+        mutableCandidates.value = result
         result
     }
 
@@ -218,17 +225,14 @@ class IntentCatalog(private val context: Context) {
             "text/plain" to "sample.txt", "text/html" to "sample.html",
             "image/jpeg" to "sample.jpg", "image/png" to "sample.png",
             "video/mp4" to "sample.mp4", "audio/mpeg" to "sample.mp3",
-            "application/pdf" to "sample.pdf", "application/zip" to "sample.zip",
-            "application/json" to "sample.json", "application/epub+zip" to "sample.epub",
-            "application/vnd.android.package-archive" to "sample.apk",
-            "application/msword" to "sample.doc",
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document" to "sample.docx",
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" to "sample.xlsx",
-            "application/vnd.ms-excel" to "sample.xls", "application/vnd.ms-powerpoint" to "sample.ppt",
-            "application/vnd.openxmlformats-officedocument.presentationml.presentation" to "sample.pptx",
-            "application/x-bittorrent" to "sample.torrent", "text/markdown" to "sample.md", "text/csv" to "sample.csv",
+            "application/pdf" to "sample.pdf", "application/epub+zip" to "sample.epub",
+            "application/vnd.android.package-archive" to "sample.apk", "application/x-bittorrent" to "sample.torrent",
+            "text/markdown" to "sample.md", "text/csv" to "sample.csv", "application/json" to "sample.json",
             "application/xml" to "sample.xml", "image/svg+xml" to "sample.svg", "image/gif" to "sample.gif",
-            "application/x-7z-compressed" to "sample.7z", "application/vnd.rar" to "sample.rar"
+            "application/zip" to "sample.zip", "application/vnd.rar" to "sample.rar",
+            "application/msword" to "sample.doc", "application/vnd.openxmlformats-officedocument.wordprocessingml.document" to "sample.docx",
+            "application/vnd.ms-excel" to "sample.xls", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" to "sample.xlsx",
+            "application/vnd.ms-powerpoint" to "sample.ppt", "application/vnd.openxmlformats-officedocument.presentationml.presentation" to "sample.pptx"
         )
     }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/data/RootComponentCatalog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/RootComponentCatalog.kt
@@ -20,18 +20,24 @@ data class RootComponent(
     val kind: CleanupKind, val component: ComponentName, val user: Int,
     val label: String, val owner: String, val icon: Bitmap?,
     val overrideState: Int?, val enabled: Boolean?, val applicationEnabled: Boolean?,
-    val blocked: String? = null
+    val blocked: String? = null,
+    val modifiedByListCleaner: Boolean = false
 ) {
     val id: String get() = "$user|${kind.name}|${component.flattenToString()}"
 }
-data class RootComponentScan(val items: List<RootComponent> = emptyList(),
-    val warning: String = "尚未扫描", val observedAt: Long = 0)
+
+data class RootComponentScan(
+    val items: List<RootComponent> = emptyList(),
+    val warning: String = "尚未扫描",
+    val observedAt: Long = 0
+)
 
 /** Only reads candidate metadata/settings. Root is requested only for explicit state changes. */
 class RootComponentCatalog(private val context: Context) {
     private val pm = context.packageManager
     private val user = android.os.Process.myUid() / 100_000
     private val icons = android.util.LruCache<String, Bitmap>(128)
+    private val historyPrefs = context.getSharedPreferences(HISTORY_PREFS, Context.MODE_PRIVATE)
     private val flags = PackageManager.MATCH_DISABLED_COMPONENTS or
         PackageManager.MATCH_DISABLED_UNTIL_USED_COMPONENTS or PackageManager.MATCH_ALL or
         PackageManager.GET_META_DATA
@@ -49,6 +55,24 @@ class RootComponentCatalog(private val context: Context) {
         }
     }
 
+    fun clearModificationHistory() {
+        historyPrefs.edit().remove(KEY_MODIFIED_IDS).apply()
+    }
+
+    private fun modifiedIds(): Set<String> = historyPrefs.getStringSet(KEY_MODIFIED_IDS, emptySet()).orEmpty().toSet()
+
+    private fun markModified(id: String) {
+        val next = modifiedIds().toMutableSet().apply {
+            add(id)
+            if (size > MAX_HISTORY) {
+                // Component ids are not time ordered in SharedPreferences. Keep a bounded deterministic subset.
+                val trimmed = sorted().takeLast(MAX_HISTORY).toSet()
+                clear(); addAll(trimmed)
+            }
+        }
+        historyPrefs.edit().putStringSet(KEY_MODIFIED_IDS, next).apply()
+    }
+
     @Suppress("DEPRECATION")
     private fun query(kind: CleanupKind): List<ComponentInfo> = when (kind) {
         CleanupKind.TILE -> pm.queryIntentServices(Intent(kind.action), flags).mapNotNull { it.serviceInfo }
@@ -63,10 +87,11 @@ class RootComponentCatalog(private val context: Context) {
     fun scan(): RootComponentScan {
         icons.evictAll()
         val errors = mutableListOf<String>()
+        val modified = modifiedIds()
         val items = CleanupKind.entries.flatMap { kind ->
             try {
                 query(kind).distinctBy { ComponentName(it.packageName, it.name) }.map { info ->
-                    read(kind, info)
+                    read(kind, info, modified)
                 }
             } catch (failure: Exception) {
                 errors += "${kind.title}扫描失败：${failure.javaClass.simpleName}"
@@ -76,7 +101,7 @@ class RootComponentCatalog(private val context: Context) {
         return RootComponentScan(items, errors.joinToString("\n"), System.currentTimeMillis())
     }
 
-    private fun read(kind: CleanupKind, info: ComponentInfo): RootComponent {
+    private fun read(kind: CleanupKind, info: ComponentInfo, modified: Set<String> = modifiedIds()): RootComponent {
         val component = ComponentName(info.packageName, info.name)
         val raw = runCatching { pm.getComponentEnabledSetting(component) }.getOrNull()
         val enabled = raw?.let { ComponentStatePolicy.enabled(it, info.enabled) }
@@ -91,11 +116,15 @@ class RootComponentCatalog(private val context: Context) {
             !appEnabled -> "所属应用已停用；本功能不会启用整个应用"
             else -> null
         }
-        return RootComponent(kind, component, user,
+        val id = "$user|${kind.name}|${component.flattenToString()}"
+        return RootComponent(
+            kind, component, user,
             runCatching { info.loadLabel(pm).toString() }.getOrDefault(component.shortClassName),
             runCatching { info.applicationInfo.loadLabel(pm).toString() }.getOrDefault(info.packageName),
             icons.get(info.packageName) ?: runCatching { info.applicationInfo.loadIcon(pm).toBitmap(96, 96) }
-                .getOrNull()?.also { icons.put(info.packageName, it) }, raw, enabled, appEnabled, blocked)
+                .getOrNull()?.also { icons.put(info.packageName, it) },
+            raw, enabled, appEnabled, blocked, id in modified
+        )
     }
 
     /** Re-discover before mutation: no arbitrary component strings from UI/imports/root output. */
@@ -112,7 +141,9 @@ class RootComponentCatalog(private val context: Context) {
         if (fresh.enabled == enable) return "系统已处于目标状态，未执行命令"
         val script = ComponentStatePolicy.command(target.component.packageName, target.component.className, user, enable)
         lastOperation = "at=${System.currentTimeMillis()} component=${target.id} requestedEnabled=$enable status=started"
-        val result = try { ComponentRootCommand.run(script) } catch (failure: Exception) {
+        val result = try {
+            ComponentRootCommand.run(script)
+        } catch (failure: Exception) {
             lastOperation += " error=${failure.javaClass.name}"
             throw IllegalStateException("Root 命令未完成：${failure.javaClass.simpleName}；请刷新核对实际状态", failure)
         }
@@ -130,6 +161,13 @@ class RootComponentCatalog(private val context: Context) {
         check(!result.timedOut && result.exitCode == 0 && observed == expected) {
             "操作未确认成功（退出码 ${result.exitCode}，系统状态 ${observed ?: "未知"}）。请核对 Root 授权并刷新；不会自动重试。"
         }
+        markModified(target.id)
         return if (enable) "已核验：组件已启用；不保证恢复原磁贴/小部件位置" else "已核验：组件已禁用；请重新打开目标选择器"
+    }
+
+    private companion object {
+        const val HISTORY_PREFS = "root_component_history"
+        const val KEY_MODIFIED_IDS = "modified_ids"
+        const val MAX_HISTORY = 4_000
     }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/data/RuleRepository.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/RuleRepository.kt
@@ -8,6 +8,9 @@ import com.yagay.ListCleaner.domain.PriorityConfig
 import com.yagay.ListCleaner.domain.IntentKind
 import com.yagay.ListCleaner.domain.ModuleConfig
 import com.yagay.ListCleaner.domain.TileConfig
+import com.yagay.ListCleaner.domain.DefaultOpenConfig
+import com.yagay.ListCleaner.domain.OpenPreset
+import com.yagay.ListCleaner.domain.OpenTypeConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,6 +26,14 @@ class RuleRepository(context: Context) {
     private val mutablePriorities = MutableStateFlow(runCatching {
         json.decodeFromString(PriorityConfig.serializer(), prefs.getString(KEY_PRIORITIES, null) ?: "{}").validated()
     }.getOrDefault(PriorityConfig()))
+    private val mutableDefaultOpen = MutableStateFlow(runCatching {
+        json.decodeFromString(DefaultOpenConfig.serializer(), prefs.getString(KEY_DEFAULT_OPEN, null) ?: "{}").validated()
+    }.getOrDefault(DefaultOpenConfig()))
+    private val mutableOpenTypes = MutableStateFlow(runCatching {
+        json.decodeFromString(OpenTypeConfig.serializer(), prefs.getString(KEY_OPEN_TYPES, null) ?: "{}").validated()
+    }.getOrDefault(OpenTypeConfig()))
+    val defaultOpen: StateFlow<DefaultOpenConfig> = mutableDefaultOpen.asStateFlow()
+    val openTypes: StateFlow<OpenTypeConfig> = mutableOpenTypes.asStateFlow()
     private val mutableDiagnostic = MutableStateFlow(prefs.getBoolean(KEY_DIAGNOSTIC, false))
     private val mutableTiles = MutableStateFlow(runCatching {
         json.decodeFromString(TileConfig.serializer(), prefs.getString(KEY_TILES, null) ?: "{}").validated()
@@ -38,29 +49,30 @@ class RuleRepository(context: Context) {
     private val mutableRevision = MutableStateFlow(0L)
     val revision: StateFlow<Long> = mutableRevision.asStateFlow()
 
-    // Existing installations may have deliberately empty rules; key presence, not count, matters.
     fun hasLocalConfiguration(): Boolean = prefs.contains(KEY_INITIALIZED) || prefs.contains(KEY_RULES) ||
-        prefs.contains(KEY_DISPLAY_MODE) || prefs.contains(KEY_BLACKLIST) || prefs.contains(KEY_PRIORITIES) || prefs.contains(KEY_TILES) || prefs.contains(KEY_HIDDEN_FROM_APPS)
+        prefs.contains(KEY_DISPLAY_MODE) || prefs.contains(KEY_BLACKLIST) || prefs.contains(KEY_PRIORITIES) ||
+        prefs.contains(KEY_TILES) || prefs.contains(KEY_HIDDEN_FROM_APPS) || prefs.contains(KEY_DEFAULT_OPEN) || prefs.contains(KEY_OPEN_TYPES)
 
     fun markInitialized() { prefs.edit().putBoolean(KEY_INITIALIZED, true).apply() }
 
     @Synchronized fun restoreRemote(config: ModuleConfig) {
         config.validated()
-        replace(config.rules, config.mode != DisplayMode.SHOW_SELECTED, config.priorities, config.mode, config.tiles)
+        replace(config.rules, config.mode != DisplayMode.SHOW_SELECTED, config.priorities, config.mode, config.tiles, config.defaultOpen, config.openTypes)
         setHiddenFromApps(config.hiddenFromApps)
         setDiagnosticMode(config.diagnostic)
         markInitialized()
     }
 
     @Synchronized fun remoteSnapshot(): ModuleConfig = ModuleConfig(
-        mutableRules.value.toSet(), mutableMode.value, mutablePriorities.value,
-        mutableDiagnostic.value, android.os.Process.myUid() % 100_000, mutableTiles.value, mutableHiddenFromApps.value.toSet()
+        rules = mutableRules.value.toSet(), mode = mutableMode.value, priorities = mutablePriorities.value,
+        diagnostic = mutableDiagnostic.value, managerAppId = android.os.Process.myUid() % 100_000,
+        tiles = mutableTiles.value, hiddenFromApps = mutableHiddenFromApps.value.toSet(),
+        defaultOpen = mutableDefaultOpen.value, openTypes = mutableOpenTypes.value
     )
 
     @Synchronized fun setHiddenFromApps(packages: Set<String>) {
         val self = "com.yagay.ListCleaner"
-        val valid = packages.asSequence()
-            .map(String::trim)
+        val valid = packages.asSequence().map(String::trim)
             .filter { it.isNotEmpty() && it != "android" && it != self && it.length <= 255 && it.none { ch -> ch.isWhitespace() || ch.isISOControl() || ch == '|' } }
             .take(2_001).toSet()
         require(valid.size <= 2_000) { "隐藏应用列表数量过多" }
@@ -69,15 +81,70 @@ class RuleRepository(context: Context) {
         mutableRevision.value++
     }
 
-    @Synchronized
-    fun setDiagnosticMode(enabled: Boolean) {
+    @Synchronized fun setDefaultOpen(preset: OpenPreset, ruleId: String?) {
+        val nextMap = mutableDefaultOpen.value.preferred.toMutableMap()
+        if (ruleId == null) nextMap.remove(preset) else {
+            val parsed = requireNotNull(ComponentRule.fromId(ruleId)) { "无效的默认打开组件" }
+            require(parsed.id == ruleId) { "默认打开组件必须使用规范化类名" }
+            if (preset == OpenPreset.BROWSER) require(parsed.kind == IntentKind.BROWSER) else require(parsed.kind == IntentKind.OPEN)
+            nextMap[preset] = ruleId
+        }
+        val next = DefaultOpenConfig(nextMap).validated()
+        if (next == mutableDefaultOpen.value) return
+        mutableDefaultOpen.value = next
+        prefs.edit().putString(KEY_DEFAULT_OPEN, json.encodeToString(DefaultOpenConfig.serializer(), next)).apply()
+        mutableRevision.value++
+    }
+
+    @Synchronized fun setOpenTypeSelected(preset: OpenPreset, rules: Collection<ComponentRule>, selected: Boolean) {
+        require(preset != OpenPreset.BROWSER)
+        val ids = rules.filter { it.kind == IntentKind.OPEN && it.isValid() }.map { requireNotNull(ComponentRule.fromId(it.id)).id }.toSet()
+        if (ids.isEmpty()) return
+        val map = mutableOpenTypes.value.rules.toMutableMap()
+        val nextSet = map[preset].orEmpty().toMutableSet().apply { if (selected) addAll(ids) else removeAll(ids) }
+        if (nextSet.isEmpty()) map.remove(preset) else map[preset] = nextSet
+        setOpenTypes(mutableOpenTypes.value.copy(rules = map))
+    }
+
+    @Synchronized fun toggleOpenType(preset: OpenPreset, rule: ComponentRule) {
+        require(preset != OpenPreset.BROWSER && rule.kind == IntentKind.OPEN && rule.isValid())
+        val current = mutableOpenTypes.value.rules[preset].orEmpty()
+        setOpenTypeSelected(preset, listOf(rule), rule.id !in current)
+    }
+
+    @Synchronized fun invertOpenTypeSelected(preset: OpenPreset, rules: Collection<ComponentRule>) {
+        require(preset != OpenPreset.BROWSER)
+        val valid = rules.filter { it.kind == IntentKind.OPEN && it.isValid() }.map { requireNotNull(ComponentRule.fromId(it.id)).id }.distinct()
+        if (valid.isEmpty()) return
+        val map = mutableOpenTypes.value.rules.toMutableMap()
+        val nextSet = map[preset].orEmpty().toMutableSet().apply { valid.forEach { if (!add(it)) remove(it) } }
+        if (nextSet.isEmpty()) map.remove(preset) else map[preset] = nextSet
+        setOpenTypes(mutableOpenTypes.value.copy(rules = map))
+    }
+
+    @Synchronized fun setOpenTypePriority(preset: OpenPreset, packages: List<String>) {
+        require(preset != OpenPreset.BROWSER)
+        val map = mutableOpenTypes.value.priorities.toMutableMap().apply {
+            if (packages.isEmpty()) remove(preset) else put(preset, packages.toList())
+        }
+        setOpenTypes(mutableOpenTypes.value.copy(priorities = map))
+    }
+
+    private fun setOpenTypes(value: OpenTypeConfig) {
+        val next = value.validated()
+        if (next == mutableOpenTypes.value) return
+        mutableOpenTypes.value = next
+        prefs.edit().putString(KEY_OPEN_TYPES, json.encodeToString(OpenTypeConfig.serializer(), next)).apply()
+        mutableRevision.value++
+    }
+
+    @Synchronized fun setDiagnosticMode(enabled: Boolean) {
         mutableDiagnostic.value = enabled
         prefs.edit().putBoolean(KEY_DIAGNOSTIC, enabled).apply()
         mutableRevision.value++
     }
 
-    @Synchronized
-    fun setPriority(kind: IntentKind, packages: List<String>) {
+    @Synchronized fun setPriority(kind: IntentKind, packages: List<String>) {
         val next = mutablePriorities.value.copy(apps = mutablePriorities.value.apps.toMutableMap().apply {
             if (packages.isEmpty()) remove(kind) else put(kind, packages.toList())
         }).validated()
@@ -86,14 +153,11 @@ class RuleRepository(context: Context) {
         mutableRevision.value++
     }
 
-    @Synchronized
-    fun setComponentTitle(ruleId: String, title: String?) {
+    @Synchronized fun setComponentTitle(ruleId: String, title: String?) {
         val parsed = requireNotNull(ComponentRule.fromId(ruleId)) { "无效的组件标识" }
         require(parsed.id == ruleId) { "组件标识必须使用规范化类名" }
         val trimmed = title?.trim().orEmpty()
-        val titles = mutablePriorities.value.titles.toMutableMap().apply {
-            if (trimmed.isEmpty()) remove(ruleId) else put(ruleId, trimmed)
-        }
+        val titles = mutablePriorities.value.titles.toMutableMap().apply { if (trimmed.isEmpty()) remove(ruleId) else put(ruleId, trimmed) }
         val next = mutablePriorities.value.copy(titles = titles).validated()
         if (next == mutablePriorities.value) return
         prefs.edit().putString(KEY_PRIORITIES, encodePriorities(next)).apply()
@@ -101,8 +165,7 @@ class RuleRepository(context: Context) {
         mutableRevision.value++
     }
 
-    fun encodePriorities(value: PriorityConfig = mutablePriorities.value): String =
-        json.encodeToString(PriorityConfig.serializer(), value)
+    fun encodePriorities(value: PriorityConfig = mutablePriorities.value): String = json.encodeToString(PriorityConfig.serializer(), value)
 
     @Synchronized fun toggle(rule: ComponentRule) {
         require(rule.isValid()) { "无效的组件规则" }
@@ -112,58 +175,66 @@ class RuleRepository(context: Context) {
 
     @Synchronized fun setSelected(rules: Collection<ComponentRule>, selected: Boolean) {
         val valid = rules.filter(ComponentRule::isValid).mapNotNull { ComponentRule.fromId(it.id) }
-        val next = mutableRules.value.toMutableSet().apply {
-            if (selected) addAll(valid) else removeAll(valid.toSet())
-        }.toSet()
+        val next = mutableRules.value.toMutableSet().apply { if (selected) addAll(valid) else removeAll(valid.toSet()) }.toSet()
         updateRules(next)
     }
 
     @Synchronized fun invertSelected(rules: Collection<ComponentRule>) {
         val valid = rules.filter(ComponentRule::isValid).mapNotNull { ComponentRule.fromId(it.id) }.distinct()
         if (valid.isEmpty()) return
-        val next = mutableRules.value.toMutableSet().apply {
-            valid.forEach { rule -> if (!add(rule)) remove(rule) }
-        }.toSet()
+        val next = mutableRules.value.toMutableSet().apply { valid.forEach { rule -> if (!add(rule)) remove(rule) } }.toSet()
         updateRules(next)
     }
 
     @Synchronized fun setDisplayMode(value: DisplayMode) {
-        // An empty whitelist is treated as disabled by the hook, so it can never blank the Resolver.
         mutableMode.value = value
         prefs.edit().putString(KEY_DISPLAY_MODE, value.name).apply()
         mutableRevision.value++
     }
 
-    @Synchronized
-    fun replace(rules: Set<ComponentRule>, blacklist: Boolean, priorities: PriorityConfig = PriorityConfig(), displayMode: DisplayMode = DisplayMode.fromStored(null, blacklist), tiles: TileConfig = TileConfig()) {
+    @Synchronized fun replace(
+        rules: Set<ComponentRule>, blacklist: Boolean, priorities: PriorityConfig = PriorityConfig(),
+        displayMode: DisplayMode = DisplayMode.fromStored(null, blacklist), tiles: TileConfig = TileConfig(),
+        defaultOpen: DefaultOpenConfig = DefaultOpenConfig(), openTypes: OpenTypeConfig = OpenTypeConfig()
+    ) {
         require(rules.size <= MAX_RULES) { "备份规则数量过多" }
         require(rules.all(ComponentRule::isValid)) { "备份包含无效组件" }
-        priorities.validated()
-        tiles.validated()
+        priorities.validated(); tiles.validated(); defaultOpen.validated(); openTypes.validated()
         mutableRules.value = rules.mapNotNull { ComponentRule.fromId(it.id) }.toSet()
         mutableMode.value = displayMode
         mutablePriorities.value = priorities
         mutableTiles.value = tiles
+        mutableDefaultOpen.value = defaultOpen
+        mutableOpenTypes.value = openTypes
         prefs.edit()
             .putStringSet(KEY_RULES, rules.map(ComponentRule::id).toSet())
             .putBoolean(KEY_BLACKLIST, blacklist)
             .putString(KEY_DISPLAY_MODE, displayMode.name)
             .putString(KEY_PRIORITIES, encodePriorities(priorities))
             .putString(KEY_TILES, json.encodeToString(TileConfig.serializer(), tiles))
+            .putString(KEY_DEFAULT_OPEN, json.encodeToString(DefaultOpenConfig.serializer(), defaultOpen))
+            .putString(KEY_OPEN_TYPES, json.encodeToString(OpenTypeConfig.serializer(), openTypes))
             .apply()
         mutableRevision.value++
     }
 
     @Synchronized fun exportJson(): String = json.encodeToString(
         RuleBackup.serializer(),
-        RuleBackup(version = 5, blacklist = mutableMode.value != DisplayMode.SHOW_SELECTED, rules = mutableRules.value, priorities = mutablePriorities.value, displayMode = mutableMode.value, tiles = mutableTiles.value, hiddenFromApps = mutableHiddenFromApps.value)
+        RuleBackup(version = 7, blacklist = mutableMode.value != DisplayMode.SHOW_SELECTED, rules = mutableRules.value,
+            priorities = mutablePriorities.value, displayMode = mutableMode.value, tiles = mutableTiles.value,
+            hiddenFromApps = mutableHiddenFromApps.value, defaultOpen = mutableDefaultOpen.value, openTypes = mutableOpenTypes.value)
     )
 
     fun importJson(content: String) {
         require(content.length <= MAX_BACKUP_CHARS) { "备份文件过大" }
         val backup = json.decodeFromString(RuleBackup.serializer(), content)
-        require(backup.version in 1..5) { "不支持的备份版本：${backup.version}" }
-        replace(backup.rules, backup.blacklist, if (backup.version == 1) PriorityConfig() else backup.priorities, if (backup.version >= 3) requireNotNull(backup.displayMode) { "备份缺少显示模式" } else DisplayMode.fromStored(null, backup.blacklist), if (backup.version >= 4) backup.tiles else TileConfig())
+        require(backup.version in 1..7) { "不支持的备份版本：${backup.version}" }
+        replace(backup.rules, backup.blacklist,
+            if (backup.version == 1) PriorityConfig() else backup.priorities,
+            if (backup.version >= 3) requireNotNull(backup.displayMode) { "备份缺少显示模式" } else DisplayMode.fromStored(null, backup.blacklist),
+            if (backup.version >= 4) backup.tiles else TileConfig(),
+            if (backup.version >= 6) backup.defaultOpen else DefaultOpenConfig(),
+            if (backup.version >= 7) backup.openTypes else OpenTypeConfig())
         setHiddenFromApps(if (backup.version >= 5) backup.hiddenFromApps else emptySet())
     }
 
@@ -184,7 +255,9 @@ class RuleRepository(context: Context) {
         const val KEY_CONFIG = "config_v1"
         const val KEY_TILES = "tile_config"
         const val KEY_HIDDEN_FROM_APPS = "hidden_from_apps"
-        val SYNCED_KEYS = setOf(KEY_RULES, KEY_BLACKLIST, KEY_DISPLAY_MODE, KEY_PRIORITIES, KEY_DIAGNOSTIC, KEY_HIDDEN_FROM_APPS)
+        const val KEY_DEFAULT_OPEN = "default_open"
+        const val KEY_OPEN_TYPES = "open_type_config"
+        val SYNCED_KEYS = setOf(KEY_RULES, KEY_BLACKLIST, KEY_DISPLAY_MODE, KEY_PRIORITIES, KEY_DIAGNOSTIC, KEY_HIDDEN_FROM_APPS, KEY_DEFAULT_OPEN, KEY_OPEN_TYPES)
         private const val LOCAL_PREFS = "rules_local"
         private const val KEY_INITIALIZED = "configuration_initialized"
         private const val MAX_RULES = 20_000

--- a/app/src/main/java/com/yagay/ListCleaner/data/RuleRepository.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/RuleRepository.kt
@@ -10,6 +10,8 @@ import com.yagay.ListCleaner.domain.ModuleConfig
 import com.yagay.ListCleaner.domain.OpenPreset
 import com.yagay.ListCleaner.domain.OpenTypeConfig
 import com.yagay.ListCleaner.domain.CustomOpenDefinition
+import com.yagay.ListCleaner.domain.VisibilityCompatConfig
+import com.yagay.ListCleaner.domain.VisibilityScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,8 +32,16 @@ class RuleRepository(context: Context) {
     }.getOrDefault(OpenTypeConfig()))
     private val mutableDiagnostic = MutableStateFlow(prefs.getBoolean(KEY_DIAGNOSTIC, false))
     private val mutableHiddenFromApps = MutableStateFlow(prefs.getStringSet(KEY_HIDDEN_FROM_APPS, emptySet()).orEmpty().toSet())
+    private val mutableVisibilityScopes = MutableStateFlow(
+        prefs.getStringSet(KEY_VISIBILITY_SCOPES, emptySet()).orEmpty().mapNotNull { name ->
+            runCatching { VisibilityScope.valueOf(name) }.getOrNull()
+        }.toSet()
+    )
+    private val mutableVisibilityFullPackages = MutableStateFlow<Map<VisibilityScope, Set<String>>>(emptyMap())
     val openTypes: StateFlow<OpenTypeConfig> = mutableOpenTypes.asStateFlow()
     val hiddenFromApps: StateFlow<Set<String>> = mutableHiddenFromApps.asStateFlow()
+    val visibilityScopes: StateFlow<Set<VisibilityScope>> = mutableVisibilityScopes.asStateFlow()
+    val visibilityFullPackages: StateFlow<Map<VisibilityScope, Set<String>>> = mutableVisibilityFullPackages.asStateFlow()
     val rules: StateFlow<Set<ComponentRule>> = mutableRules.asStateFlow()
     val displayMode: StateFlow<DisplayMode> = mutableMode.asStateFlow()
     val priorities: StateFlow<PriorityConfig> = mutablePriorities.asStateFlow()
@@ -41,7 +51,7 @@ class RuleRepository(context: Context) {
 
     fun hasLocalConfiguration(): Boolean = prefs.contains(KEY_INITIALIZED) || prefs.contains(KEY_RULES) ||
         prefs.contains(KEY_DISPLAY_MODE) || prefs.contains(KEY_BLACKLIST) || prefs.contains(KEY_PRIORITIES) ||
-        prefs.contains(KEY_HIDDEN_FROM_APPS) || prefs.contains(KEY_OPEN_TYPES) ||
+        prefs.contains(KEY_HIDDEN_FROM_APPS) || prefs.contains(KEY_OPEN_TYPES) || prefs.contains(KEY_VISIBILITY_SCOPES) ||
         prefs.contains(KEY_TILES) || prefs.contains(KEY_DEFAULT_OPEN)
 
     fun markInitialized() {
@@ -52,6 +62,7 @@ class RuleRepository(context: Context) {
         config.validated()
         replace(config.rules, config.mode != DisplayMode.SHOW_SELECTED, config.priorities, config.mode, config.openTypes)
         setHiddenFromApps(config.hiddenFromApps)
+        setVisibilityScopes(config.visibilityCompat.scopes)
         setDiagnosticMode(config.diagnostic)
         markInitialized()
     }
@@ -60,7 +71,11 @@ class RuleRepository(context: Context) {
     @Synchronized fun remoteSnapshot(): ModuleConfig = ModuleConfig(
         rules = mutableRules.value.toSet(), mode = mutableMode.value, priorities = mutablePriorities.value,
         diagnostic = mutableDiagnostic.value, managerAppId = android.os.Process.myUid() % 100_000,
-        hiddenFromApps = mutableHiddenFromApps.value.toSet(), openTypes = mutableOpenTypes.value
+        hiddenFromApps = mutableHiddenFromApps.value.toSet(), openTypes = mutableOpenTypes.value,
+        visibilityCompat = VisibilityCompatConfig(
+            scopes = mutableVisibilityScopes.value.toSet(),
+            fullPackages = mutableVisibilityFullPackages.value.mapValues { it.value.toSet() }
+        ).validated()
     )
 
     @Synchronized fun setHiddenFromApps(packages: Set<String>) {
@@ -72,6 +87,23 @@ class RuleRepository(context: Context) {
         if (valid == mutableHiddenFromApps.value) return
         mutableHiddenFromApps.value = valid
         prefs.edit().putStringSet(KEY_HIDDEN_FROM_APPS, valid).apply()
+        mutableRevision.value++
+    }
+
+    @Synchronized fun setVisibilityScopes(scopes: Set<VisibilityScope>) {
+        val valid = scopes.toSet()
+        if (valid == mutableVisibilityScopes.value) return
+        mutableVisibilityScopes.value = valid
+        prefs.edit().putStringSet(KEY_VISIBILITY_SCOPES, valid.map { it.name }.toSet()).apply()
+        mutableRevision.value++
+    }
+
+    /** Derived from the current candidate catalog. Not backed up; rebuilt after scans/rule changes. */
+    @Synchronized fun setVisibilityFullPackages(packages: Map<VisibilityScope, Set<String>>) {
+        val next = VisibilityCompatConfig(fullPackages = packages).validated().fullPackages
+            .mapValues { it.value.toSet() }
+        if (next == mutableVisibilityFullPackages.value) return
+        mutableVisibilityFullPackages.value = next
         mutableRevision.value++
     }
 
@@ -200,6 +232,7 @@ class RuleRepository(context: Context) {
         mutableMode.value = displayMode
         mutablePriorities.value = priorities
         mutableOpenTypes.value = openTypes.validated()
+        mutableVisibilityFullPackages.value = emptyMap()
         prefs.edit()
             .putStringSet(KEY_RULES, mutableRules.value.map(ComponentRule::id).toSet())
             .putBoolean(KEY_BLACKLIST, blacklist)
@@ -214,21 +247,23 @@ class RuleRepository(context: Context) {
 
     @Synchronized fun exportJson(): String = json.encodeToString(
         RuleBackup.serializer(),
-        RuleBackup(version = 8, blacklist = mutableMode.value != DisplayMode.SHOW_SELECTED, rules = mutableRules.value,
+        RuleBackup(version = 9, blacklist = mutableMode.value != DisplayMode.SHOW_SELECTED, rules = mutableRules.value,
             priorities = mutablePriorities.value, displayMode = mutableMode.value,
-            hiddenFromApps = mutableHiddenFromApps.value, openTypes = mutableOpenTypes.value)
+            hiddenFromApps = mutableHiddenFromApps.value, openTypes = mutableOpenTypes.value,
+            visibilityScopes = mutableVisibilityScopes.value)
     )
 
     fun importJson(content: String) {
         require(content.length <= MAX_BACKUP_CHARS) { "备份文件过大" }
         val backup = json.decodeFromString(RuleBackup.serializer(), content)
-        require(backup.version in 1..8) { "不支持的备份版本：${backup.version}" }
+        require(backup.version in 1..9) { "不支持的备份版本：${backup.version}" }
         // Legacy tiles/defaultOpen are deliberately ignored: those features no longer have runtime consumers.
         replace(backup.rules, backup.blacklist,
             if (backup.version == 1) PriorityConfig() else backup.priorities,
             if (backup.version >= 3) requireNotNull(backup.displayMode) { "备份缺少显示模式" } else DisplayMode.fromStored(null, backup.blacklist),
             if (backup.version >= 7) backup.openTypes else OpenTypeConfig())
         setHiddenFromApps(if (backup.version >= 5) backup.hiddenFromApps else emptySet())
+        setVisibilityScopes(if (backup.version >= 9) backup.visibilityScopes else emptySet())
         markInitialized()
     }
 
@@ -253,7 +288,9 @@ class RuleRepository(context: Context) {
         const val KEY_DEFAULT_OPEN = "default_open"
         const val KEY_HIDDEN_FROM_APPS = "hidden_from_apps"
         const val KEY_OPEN_TYPES = "open_type_config"
-        val SYNCED_KEYS = setOf(KEY_RULES, KEY_BLACKLIST, KEY_DISPLAY_MODE, KEY_PRIORITIES, KEY_DIAGNOSTIC, KEY_HIDDEN_FROM_APPS, KEY_OPEN_TYPES)
+        const val KEY_VISIBILITY_SCOPES = "visibility_scopes"
+        val SYNCED_KEYS = setOf(KEY_RULES, KEY_BLACKLIST, KEY_DISPLAY_MODE, KEY_PRIORITIES, KEY_DIAGNOSTIC,
+            KEY_HIDDEN_FROM_APPS, KEY_OPEN_TYPES, KEY_VISIBILITY_SCOPES)
         private const val LOCAL_PREFS = "rules_local"
         private const val KEY_INITIALIZED = "configuration_initialized"
         private const val MAX_RULES = 20_000

--- a/app/src/main/java/com/yagay/ListCleaner/data/RuleRepository.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/RuleRepository.kt
@@ -7,8 +7,6 @@ import com.yagay.ListCleaner.domain.DisplayMode
 import com.yagay.ListCleaner.domain.PriorityConfig
 import com.yagay.ListCleaner.domain.IntentKind
 import com.yagay.ListCleaner.domain.ModuleConfig
-import com.yagay.ListCleaner.domain.TileConfig
-import com.yagay.ListCleaner.domain.DefaultOpenConfig
 import com.yagay.ListCleaner.domain.OpenPreset
 import com.yagay.ListCleaner.domain.OpenTypeConfig
 import com.yagay.ListCleaner.domain.CustomOpenDefinition
@@ -27,22 +25,13 @@ class RuleRepository(context: Context) {
     private val mutablePriorities = MutableStateFlow(runCatching {
         json.decodeFromString(PriorityConfig.serializer(), prefs.getString(KEY_PRIORITIES, null) ?: "{}").validated()
     }.getOrDefault(PriorityConfig()))
-    private val mutableDefaultOpen = MutableStateFlow(runCatching {
-        json.decodeFromString(DefaultOpenConfig.serializer(), prefs.getString(KEY_DEFAULT_OPEN, null) ?: "{}").validated()
-    }.getOrDefault(DefaultOpenConfig()))
     private val mutableOpenTypes = MutableStateFlow(runCatching {
         json.decodeFromString(OpenTypeConfig.serializer(), prefs.getString(KEY_OPEN_TYPES, null) ?: "{}").validated()
     }.getOrDefault(OpenTypeConfig()))
-    val defaultOpen: StateFlow<DefaultOpenConfig> = mutableDefaultOpen.asStateFlow()
-    val openTypes: StateFlow<OpenTypeConfig> = mutableOpenTypes.asStateFlow()
     private val mutableDiagnostic = MutableStateFlow(prefs.getBoolean(KEY_DIAGNOSTIC, false))
-    private val mutableTiles = MutableStateFlow(runCatching {
-        json.decodeFromString(TileConfig.serializer(), prefs.getString(KEY_TILES, null) ?: "{}").validated()
-    }.getOrDefault(TileConfig()))
     private val mutableHiddenFromApps = MutableStateFlow(prefs.getStringSet(KEY_HIDDEN_FROM_APPS, emptySet()).orEmpty().toSet())
-    val tiles: StateFlow<TileConfig> = mutableTiles.asStateFlow()
+    val openTypes: StateFlow<OpenTypeConfig> = mutableOpenTypes.asStateFlow()
     val hiddenFromApps: StateFlow<Set<String>> = mutableHiddenFromApps.asStateFlow()
-
     val rules: StateFlow<Set<ComponentRule>> = mutableRules.asStateFlow()
     val displayMode: StateFlow<DisplayMode> = mutableMode.asStateFlow()
     val priorities: StateFlow<PriorityConfig> = mutablePriorities.asStateFlow()
@@ -52,23 +41,26 @@ class RuleRepository(context: Context) {
 
     fun hasLocalConfiguration(): Boolean = prefs.contains(KEY_INITIALIZED) || prefs.contains(KEY_RULES) ||
         prefs.contains(KEY_DISPLAY_MODE) || prefs.contains(KEY_BLACKLIST) || prefs.contains(KEY_PRIORITIES) ||
-        prefs.contains(KEY_TILES) || prefs.contains(KEY_HIDDEN_FROM_APPS) || prefs.contains(KEY_DEFAULT_OPEN) || prefs.contains(KEY_OPEN_TYPES)
+        prefs.contains(KEY_HIDDEN_FROM_APPS) || prefs.contains(KEY_OPEN_TYPES) ||
+        prefs.contains(KEY_TILES) || prefs.contains(KEY_DEFAULT_OPEN)
 
-    fun markInitialized() { prefs.edit().putBoolean(KEY_INITIALIZED, true).apply() }
+    fun markInitialized() {
+        prefs.edit().putBoolean(KEY_INITIALIZED, true).remove(KEY_TILES).remove(KEY_DEFAULT_OPEN).apply()
+    }
 
     @Synchronized fun restoreRemote(config: ModuleConfig) {
         config.validated()
-        replace(config.rules, config.mode != DisplayMode.SHOW_SELECTED, config.priorities, config.mode, config.tiles, config.defaultOpen, config.openTypes)
+        replace(config.rules, config.mode != DisplayMode.SHOW_SELECTED, config.priorities, config.mode, config.openTypes)
         setHiddenFromApps(config.hiddenFromApps)
         setDiagnosticMode(config.diagnostic)
         markInitialized()
     }
 
+    /** Legacy ModuleConfig fields remain deserializable, but new remote snapshots always use defaults. */
     @Synchronized fun remoteSnapshot(): ModuleConfig = ModuleConfig(
         rules = mutableRules.value.toSet(), mode = mutableMode.value, priorities = mutablePriorities.value,
         diagnostic = mutableDiagnostic.value, managerAppId = android.os.Process.myUid() % 100_000,
-        tiles = mutableTiles.value, hiddenFromApps = mutableHiddenFromApps.value.toSet(),
-        defaultOpen = mutableDefaultOpen.value, openTypes = mutableOpenTypes.value
+        hiddenFromApps = mutableHiddenFromApps.value.toSet(), openTypes = mutableOpenTypes.value
     )
 
     @Synchronized fun setHiddenFromApps(packages: Set<String>) {
@@ -77,23 +69,9 @@ class RuleRepository(context: Context) {
             .filter { it.isNotEmpty() && it != "android" && it != self && it.length <= 255 && it.none { ch -> ch.isWhitespace() || ch.isISOControl() || ch == '|' } }
             .take(2_001).toSet()
         require(valid.size <= 2_000) { "隐藏应用列表数量过多" }
+        if (valid == mutableHiddenFromApps.value) return
         mutableHiddenFromApps.value = valid
         prefs.edit().putStringSet(KEY_HIDDEN_FROM_APPS, valid).apply()
-        mutableRevision.value++
-    }
-
-    @Synchronized fun setDefaultOpen(preset: OpenPreset, ruleId: String?) {
-        val nextMap = mutableDefaultOpen.value.preferred.toMutableMap()
-        if (ruleId == null) nextMap.remove(preset) else {
-            val parsed = requireNotNull(ComponentRule.fromId(ruleId)) { "无效的默认打开组件" }
-            require(parsed.id == ruleId) { "默认打开组件必须使用规范化类名" }
-            if (preset == OpenPreset.BROWSER) require(parsed.kind == IntentKind.BROWSER) else require(parsed.kind == IntentKind.OPEN)
-            nextMap[preset] = ruleId
-        }
-        val next = DefaultOpenConfig(nextMap).validated()
-        if (next == mutableDefaultOpen.value) return
-        mutableDefaultOpen.value = next
-        prefs.edit().putString(KEY_DEFAULT_OPEN, json.encodeToString(DefaultOpenConfig.serializer(), next)).apply()
         mutableRevision.value++
     }
 
@@ -107,9 +85,7 @@ class RuleRepository(context: Context) {
             definitions.remove(preset)
             rules.remove(preset)
             priorities.remove(preset)
-        } else {
-            definitions[preset] = definition.validated()
-        }
+        } else definitions[preset] = definition.validated()
         setOpenTypes(current.copy(rules = rules, priorities = priorities, customDefinitions = definitions))
     }
 
@@ -126,8 +102,7 @@ class RuleRepository(context: Context) {
 
     @Synchronized fun toggleOpenType(preset: OpenPreset, rule: ComponentRule) {
         require(preset != OpenPreset.BROWSER && rule.kind == IntentKind.OPEN && rule.isValid())
-        val current = mutableOpenTypes.value.rules[preset].orEmpty()
-        setOpenTypeSelected(preset, listOf(rule), rule.id !in current)
+        setOpenTypeSelected(preset, listOf(rule), rule.id !in mutableOpenTypes.value.rules[preset].orEmpty())
     }
 
     @Synchronized fun invertOpenTypeSelected(preset: OpenPreset, rules: Collection<ComponentRule>) {
@@ -159,6 +134,7 @@ class RuleRepository(context: Context) {
     }
 
     @Synchronized fun setDiagnosticMode(enabled: Boolean) {
+        if (mutableDiagnostic.value == enabled) return
         mutableDiagnostic.value = enabled
         prefs.edit().putBoolean(KEY_DIAGNOSTIC, enabled).apply()
         mutableRevision.value++
@@ -168,6 +144,7 @@ class RuleRepository(context: Context) {
         val next = mutablePriorities.value.copy(apps = mutablePriorities.value.apps.toMutableMap().apply {
             if (packages.isEmpty()) remove(kind) else put(kind, packages.toList())
         }).validated()
+        if (next == mutablePriorities.value) return
         prefs.edit().putString(KEY_PRIORITIES, encodePriorities(next)).apply()
         mutablePriorities.value = next
         mutableRevision.value++
@@ -202,11 +179,11 @@ class RuleRepository(context: Context) {
     @Synchronized fun invertSelected(rules: Collection<ComponentRule>) {
         val valid = rules.filter(ComponentRule::isValid).mapNotNull { ComponentRule.fromId(it.id) }.distinct()
         if (valid.isEmpty()) return
-        val next = mutableRules.value.toMutableSet().apply { valid.forEach { rule -> if (!add(rule)) remove(rule) } }.toSet()
-        updateRules(next)
+        updateRules(mutableRules.value.toMutableSet().apply { valid.forEach { rule -> if (!add(rule)) remove(rule) } }.toSet())
     }
 
     @Synchronized fun setDisplayMode(value: DisplayMode) {
+        if (mutableMode.value == value) return
         mutableMode.value = value
         prefs.edit().putString(KEY_DISPLAY_MODE, value.name).apply()
         mutableRevision.value++
@@ -214,26 +191,23 @@ class RuleRepository(context: Context) {
 
     @Synchronized fun replace(
         rules: Set<ComponentRule>, blacklist: Boolean, priorities: PriorityConfig = PriorityConfig(),
-        displayMode: DisplayMode = DisplayMode.fromStored(null, blacklist), tiles: TileConfig = TileConfig(),
-        defaultOpen: DefaultOpenConfig = DefaultOpenConfig(), openTypes: OpenTypeConfig = OpenTypeConfig()
+        displayMode: DisplayMode = DisplayMode.fromStored(null, blacklist), openTypes: OpenTypeConfig = OpenTypeConfig()
     ) {
         require(rules.size <= MAX_RULES) { "备份规则数量过多" }
         require(rules.all(ComponentRule::isValid)) { "备份包含无效组件" }
-        priorities.validated(); tiles.validated(); defaultOpen.validated(); openTypes.validated()
+        priorities.validated(); openTypes.validated()
         mutableRules.value = rules.mapNotNull { ComponentRule.fromId(it.id) }.toSet()
         mutableMode.value = displayMode
         mutablePriorities.value = priorities
-        mutableTiles.value = tiles
-        mutableDefaultOpen.value = defaultOpen
-        mutableOpenTypes.value = openTypes
+        mutableOpenTypes.value = openTypes.validated()
         prefs.edit()
-            .putStringSet(KEY_RULES, rules.map(ComponentRule::id).toSet())
+            .putStringSet(KEY_RULES, mutableRules.value.map(ComponentRule::id).toSet())
             .putBoolean(KEY_BLACKLIST, blacklist)
             .putString(KEY_DISPLAY_MODE, displayMode.name)
             .putString(KEY_PRIORITIES, encodePriorities(priorities))
-            .putString(KEY_TILES, json.encodeToString(TileConfig.serializer(), tiles))
-            .putString(KEY_DEFAULT_OPEN, json.encodeToString(DefaultOpenConfig.serializer(), defaultOpen))
-            .putString(KEY_OPEN_TYPES, json.encodeToString(OpenTypeConfig.serializer(), openTypes))
+            .putString(KEY_OPEN_TYPES, json.encodeToString(OpenTypeConfig.serializer(), mutableOpenTypes.value))
+            .remove(KEY_TILES)
+            .remove(KEY_DEFAULT_OPEN)
             .apply()
         mutableRevision.value++
     }
@@ -241,25 +215,26 @@ class RuleRepository(context: Context) {
     @Synchronized fun exportJson(): String = json.encodeToString(
         RuleBackup.serializer(),
         RuleBackup(version = 8, blacklist = mutableMode.value != DisplayMode.SHOW_SELECTED, rules = mutableRules.value,
-            priorities = mutablePriorities.value, displayMode = mutableMode.value, tiles = mutableTiles.value,
-            hiddenFromApps = mutableHiddenFromApps.value, defaultOpen = mutableDefaultOpen.value, openTypes = mutableOpenTypes.value)
+            priorities = mutablePriorities.value, displayMode = mutableMode.value,
+            hiddenFromApps = mutableHiddenFromApps.value, openTypes = mutableOpenTypes.value)
     )
 
     fun importJson(content: String) {
         require(content.length <= MAX_BACKUP_CHARS) { "备份文件过大" }
         val backup = json.decodeFromString(RuleBackup.serializer(), content)
         require(backup.version in 1..8) { "不支持的备份版本：${backup.version}" }
+        // Legacy tiles/defaultOpen are deliberately ignored: those features no longer have runtime consumers.
         replace(backup.rules, backup.blacklist,
             if (backup.version == 1) PriorityConfig() else backup.priorities,
             if (backup.version >= 3) requireNotNull(backup.displayMode) { "备份缺少显示模式" } else DisplayMode.fromStored(null, backup.blacklist),
-            if (backup.version >= 4) backup.tiles else TileConfig(),
-            if (backup.version >= 6) backup.defaultOpen else DefaultOpenConfig(),
             if (backup.version >= 7) backup.openTypes else OpenTypeConfig())
         setHiddenFromApps(if (backup.version >= 5) backup.hiddenFromApps else emptySet())
+        markInitialized()
     }
 
     private fun updateRules(next: Set<ComponentRule>) {
         require(next.size <= MAX_RULES) { "规则数量过多" }
+        if (next == mutableRules.value) return
         mutableRules.value = next
         prefs.edit().putStringSet(KEY_RULES, next.map(ComponentRule::id).toSet()).apply()
         mutableRevision.value++
@@ -273,11 +248,12 @@ class RuleRepository(context: Context) {
         const val KEY_PRIORITIES = "priority_apps"
         const val KEY_DIAGNOSTIC = "diagnostic_mode"
         const val KEY_CONFIG = "config_v1"
+        /** Legacy keys retained only so upgrades can detect and erase old local state. */
         const val KEY_TILES = "tile_config"
-        const val KEY_HIDDEN_FROM_APPS = "hidden_from_apps"
         const val KEY_DEFAULT_OPEN = "default_open"
+        const val KEY_HIDDEN_FROM_APPS = "hidden_from_apps"
         const val KEY_OPEN_TYPES = "open_type_config"
-        val SYNCED_KEYS = setOf(KEY_RULES, KEY_BLACKLIST, KEY_DISPLAY_MODE, KEY_PRIORITIES, KEY_DIAGNOSTIC, KEY_HIDDEN_FROM_APPS, KEY_DEFAULT_OPEN, KEY_OPEN_TYPES)
+        val SYNCED_KEYS = setOf(KEY_RULES, KEY_BLACKLIST, KEY_DISPLAY_MODE, KEY_PRIORITIES, KEY_DIAGNOSTIC, KEY_HIDDEN_FROM_APPS, KEY_OPEN_TYPES)
         private const val LOCAL_PREFS = "rules_local"
         private const val KEY_INITIALIZED = "configuration_initialized"
         private const val MAX_RULES = 20_000

--- a/app/src/main/java/com/yagay/ListCleaner/data/RuleRepository.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/RuleRepository.kt
@@ -11,6 +11,7 @@ import com.yagay.ListCleaner.domain.TileConfig
 import com.yagay.ListCleaner.domain.DefaultOpenConfig
 import com.yagay.ListCleaner.domain.OpenPreset
 import com.yagay.ListCleaner.domain.OpenTypeConfig
+import com.yagay.ListCleaner.domain.CustomOpenDefinition
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -96,8 +97,25 @@ class RuleRepository(context: Context) {
         mutableRevision.value++
     }
 
+    @Synchronized fun setCustomOpenDefinition(preset: OpenPreset, definition: CustomOpenDefinition?) {
+        require(preset.isCustom) { "只能编辑自定义打开类型槽位" }
+        val current = mutableOpenTypes.value
+        val definitions = current.customDefinitions.toMutableMap()
+        val rules = current.rules.toMutableMap()
+        val priorities = current.priorities.toMutableMap()
+        if (definition == null) {
+            definitions.remove(preset)
+            rules.remove(preset)
+            priorities.remove(preset)
+        } else {
+            definitions[preset] = definition.validated()
+        }
+        setOpenTypes(current.copy(rules = rules, priorities = priorities, customDefinitions = definitions))
+    }
+
     @Synchronized fun setOpenTypeSelected(preset: OpenPreset, rules: Collection<ComponentRule>, selected: Boolean) {
         require(preset != OpenPreset.BROWSER)
+        if (preset.isCustom) require(preset in mutableOpenTypes.value.customDefinitions) { "自定义类型尚未配置" }
         val ids = rules.filter { it.kind == IntentKind.OPEN && it.isValid() }.map { requireNotNull(ComponentRule.fromId(it.id)).id }.toSet()
         if (ids.isEmpty()) return
         val map = mutableOpenTypes.value.rules.toMutableMap()
@@ -114,6 +132,7 @@ class RuleRepository(context: Context) {
 
     @Synchronized fun invertOpenTypeSelected(preset: OpenPreset, rules: Collection<ComponentRule>) {
         require(preset != OpenPreset.BROWSER)
+        if (preset.isCustom) require(preset in mutableOpenTypes.value.customDefinitions) { "自定义类型尚未配置" }
         val valid = rules.filter { it.kind == IntentKind.OPEN && it.isValid() }.map { requireNotNull(ComponentRule.fromId(it.id)).id }.distinct()
         if (valid.isEmpty()) return
         val map = mutableOpenTypes.value.rules.toMutableMap()
@@ -124,6 +143,7 @@ class RuleRepository(context: Context) {
 
     @Synchronized fun setOpenTypePriority(preset: OpenPreset, packages: List<String>) {
         require(preset != OpenPreset.BROWSER)
+        if (preset.isCustom) require(preset in mutableOpenTypes.value.customDefinitions) { "自定义类型尚未配置" }
         val map = mutableOpenTypes.value.priorities.toMutableMap().apply {
             if (packages.isEmpty()) remove(preset) else put(preset, packages.toList())
         }
@@ -220,7 +240,7 @@ class RuleRepository(context: Context) {
 
     @Synchronized fun exportJson(): String = json.encodeToString(
         RuleBackup.serializer(),
-        RuleBackup(version = 7, blacklist = mutableMode.value != DisplayMode.SHOW_SELECTED, rules = mutableRules.value,
+        RuleBackup(version = 8, blacklist = mutableMode.value != DisplayMode.SHOW_SELECTED, rules = mutableRules.value,
             priorities = mutablePriorities.value, displayMode = mutableMode.value, tiles = mutableTiles.value,
             hiddenFromApps = mutableHiddenFromApps.value, defaultOpen = mutableDefaultOpen.value, openTypes = mutableOpenTypes.value)
     )
@@ -228,7 +248,7 @@ class RuleRepository(context: Context) {
     fun importJson(content: String) {
         require(content.length <= MAX_BACKUP_CHARS) { "备份文件过大" }
         val backup = json.decodeFromString(RuleBackup.serializer(), content)
-        require(backup.version in 1..7) { "不支持的备份版本：${backup.version}" }
+        require(backup.version in 1..8) { "不支持的备份版本：${backup.version}" }
         replace(backup.rules, backup.blacklist,
             if (backup.version == 1) PriorityConfig() else backup.priorities,
             if (backup.version >= 3) requireNotNull(backup.displayMode) { "备份缺少显示模式" } else DisplayMode.fromStored(null, backup.blacklist),

--- a/app/src/main/java/com/yagay/ListCleaner/domain/DefaultOpenConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/DefaultOpenConfig.kt
@@ -27,9 +27,24 @@ enum class OpenPreset(val title: String, val description: String) {
     GEO("地图位置", "geo:"),
     MAILTO("邮件链接", "mailto:"),
     TEL("电话链接", "tel:"),
-    SMS("短信链接", "sms: / smsto:")
+    SMS("短信链接", "sms: / smsto:"),
+    CUSTOM_1("自定义 1", "用户定义"),
+    CUSTOM_2("自定义 2", "用户定义"),
+    CUSTOM_3("自定义 3", "用户定义"),
+    CUSTOM_4("自定义 4", "用户定义"),
+    CUSTOM_5("自定义 5", "用户定义"),
+    CUSTOM_6("自定义 6", "用户定义"),
+    CUSTOM_7("自定义 7", "用户定义"),
+    CUSTOM_8("自定义 8", "用户定义");
+
+    val isCustom: Boolean get() = this in CUSTOM_SLOTS
+
+    companion object {
+        val CUSTOM_SLOTS = listOf(CUSTOM_1, CUSTOM_2, CUSTOM_3, CUSTOM_4, CUSTOM_5, CUSTOM_6, CUSTOM_7, CUSTOM_8)
+    }
 }
 
+/** Deprecated backup compatibility only. Runtime no longer applies a forced default handler. */
 @Serializable
 data class DefaultOpenConfig(
     val preferred: Map<OpenPreset, String> = emptyMap()
@@ -47,18 +62,12 @@ data class DefaultOpenConfig(
     }
 }
 
-/**
- * Classifies a resolver request into one of the typed OPEN buckets.
- *
- * MIME/scheme remains authoritative. [fileNameOrPath] is only used as a compatibility fallback
- * for file managers that send no MIME, a wildcard MIME, or an opaque binary MIME such as
- * `application/octet-stream` (ES File Explorer and similar apps may do this for some files).
- */
 fun matchOpenPreset(
     kind: IntentKind,
     mimeType: String?,
     scheme: String?,
-    fileNameOrPath: String? = null
+    fileNameOrPath: String? = null,
+    customDefinitions: Map<OpenPreset, CustomOpenDefinition> = emptyMap()
 ): OpenPreset? {
     val normalizedScheme = scheme?.lowercase()
     if (kind == IntentKind.BROWSER && normalizedScheme in setOf("http", "https")) return OpenPreset.BROWSER
@@ -73,6 +82,12 @@ fun matchOpenPreset(
     }
 
     val mime = mimeType?.substringBefore(';')?.trim()?.lowercase().orEmpty()
+    customDefinitions.entries.firstOrNull { (_, definition) ->
+        definition.mimeTypes.any { configured ->
+            configured == mime || configured.endsWith("/*") && mime.startsWith(configured.removeSuffix("*"))
+        }
+    }?.let { return it.key }
+
     val mimePreset = when {
         mime == "application/pdf" -> OpenPreset.PDF
         mime in setOf("application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") -> OpenPreset.WORD
@@ -84,7 +99,6 @@ fun matchOpenPreset(
         mime in setOf("text/markdown", "text/x-markdown") -> OpenPreset.MARKDOWN
         mime in setOf("text/csv", "application/csv") -> OpenPreset.CSV
         mime in setOf("application/json", "text/json") || mime.endsWith("+json") -> OpenPreset.JSON
-        // SVG is XML-based, so it must beat the generic +xml rule.
         mime == "image/svg+xml" -> OpenPreset.SVG
         mime == "image/gif" -> OpenPreset.GIF
         mime in setOf("application/xml", "text/xml") || mime.endsWith("+xml") -> OpenPreset.XML
@@ -101,8 +115,11 @@ fun matchOpenPreset(
     }
     if (mimePreset != null) return mimePreset
 
-    // Do not second-guess a specific, unknown MIME. Extension fallback is deliberately limited to
-    // absent/wildcard/binary MIME values that commonly lose the real file type in file managers.
+    val extension = normalizedExtension(fileNameOrPath)
+    if (extension != null) {
+        customDefinitions.entries.firstOrNull { (_, definition) -> extension in definition.extensions }?.let { return it.key }
+    }
+
     if (mime.isNotEmpty() && mime !in OPAQUE_FILE_MIMES) return null
     return matchOpenPresetByExtension(fileNameOrPath)
 }
@@ -114,12 +131,14 @@ private val OPAQUE_FILE_MIMES = setOf(
     "application/x-download"
 )
 
-private fun matchOpenPresetByExtension(fileNameOrPath: String?): OpenPreset? {
+private fun normalizedExtension(fileNameOrPath: String?): String? {
     val clean = fileNameOrPath?.trim()?.substringBefore('?')?.substringBefore('#')?.lowercase().orEmpty()
     if (clean.isEmpty()) return null
-    val extension = clean.substringAfterLast('/', clean).substringAfterLast('.', "")
-    if (extension.isEmpty()) return null
-    return when (extension) {
+    return clean.substringAfterLast('/', clean).substringAfterLast('.', "").takeIf { it.isNotEmpty() }
+}
+
+private fun matchOpenPresetByExtension(fileNameOrPath: String?): OpenPreset? {
+    return when (normalizedExtension(fileNameOrPath)) {
         "pdf" -> OpenPreset.PDF
         "doc", "docx" -> OpenPreset.WORD
         "xls", "xlsx" -> OpenPreset.EXCEL
@@ -142,12 +161,15 @@ private fun matchOpenPresetByExtension(fileNameOrPath: String?): OpenPreset? {
     }
 }
 
-/** Uses scan evidence so the rules/sort pages only show components that actually matched this preset probe. */
-fun ComponentCandidate.matchesOpenPreset(preset: OpenPreset): Boolean {
+fun ComponentCandidate.matchesOpenPreset(
+    preset: OpenPreset,
+    customDefinitions: Map<OpenPreset, CustomOpenDefinition> = emptyMap()
+): Boolean {
     if (preset == OpenPreset.BROWSER || rule.kind != IntentKind.OPEN) return false
     return evidence.any { line ->
         val mime = Regex("(?:^|\\s)mime=([^\\s]+)").find(line)?.groupValues?.getOrNull(1)
         val scheme = Regex("(?:^|\\s)scheme=([^\\s]+)").find(line)?.groupValues?.getOrNull(1)
-        matchOpenPreset(IntentKind.OPEN, mime, scheme) == preset
+        val sample = Regex("(?:^|\\s)sample=([^\\s]+)").find(line)?.groupValues?.getOrNull(1)
+        matchOpenPreset(IntentKind.OPEN, mime, scheme, sample, customDefinitions) == preset
     }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/domain/DefaultOpenConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/DefaultOpenConfig.kt
@@ -67,7 +67,7 @@ fun matchOpenPreset(
     mimeType: String?,
     scheme: String?,
     fileNameOrPath: String? = null,
-    customDefinitions: Map<OpenPreset, CustomOpenDefinition> = emptyMap()
+    customDefinitions: Map<OpenPreset, CustomOpenDefinition> = CustomOpenRegistry.snapshot()
 ): OpenPreset? {
     val normalizedScheme = scheme?.lowercase()
     if (kind == IntentKind.BROWSER && normalizedScheme in setOf("http", "https")) return OpenPreset.BROWSER
@@ -137,33 +137,31 @@ private fun normalizedExtension(fileNameOrPath: String?): String? {
     return clean.substringAfterLast('/', clean).substringAfterLast('.', "").takeIf { it.isNotEmpty() }
 }
 
-private fun matchOpenPresetByExtension(fileNameOrPath: String?): OpenPreset? {
-    return when (normalizedExtension(fileNameOrPath)) {
-        "pdf" -> OpenPreset.PDF
-        "doc", "docx" -> OpenPreset.WORD
-        "xls", "xlsx" -> OpenPreset.EXCEL
-        "ppt", "pptx" -> OpenPreset.POWERPOINT
-        "epub" -> OpenPreset.EPUB
-        "apk", "apks", "xapk" -> OpenPreset.APK
-        "torrent" -> OpenPreset.TORRENT
-        "md", "markdown" -> OpenPreset.MARKDOWN
-        "csv" -> OpenPreset.CSV
-        "json" -> OpenPreset.JSON
-        "xml" -> OpenPreset.XML
-        "svg" -> OpenPreset.SVG
-        "gif" -> OpenPreset.GIF
-        "jpg", "jpeg", "png", "webp", "bmp", "heic", "heif", "avif" -> OpenPreset.IMAGE
-        "mp4", "mkv", "webm", "avi", "mov", "m4v", "3gp" -> OpenPreset.VIDEO
-        "mp3", "m4a", "aac", "flac", "wav", "ogg", "opus" -> OpenPreset.AUDIO
-        "txt", "log", "ini", "conf", "cfg" -> OpenPreset.TEXT
-        "zip", "rar", "7z", "tar", "gz", "gzip", "tgz", "bz2", "xz" -> OpenPreset.ARCHIVE
-        else -> null
-    }
+private fun matchOpenPresetByExtension(fileNameOrPath: String?): OpenPreset? = when (normalizedExtension(fileNameOrPath)) {
+    "pdf" -> OpenPreset.PDF
+    "doc", "docx" -> OpenPreset.WORD
+    "xls", "xlsx" -> OpenPreset.EXCEL
+    "ppt", "pptx" -> OpenPreset.POWERPOINT
+    "epub" -> OpenPreset.EPUB
+    "apk", "apks", "xapk" -> OpenPreset.APK
+    "torrent" -> OpenPreset.TORRENT
+    "md", "markdown" -> OpenPreset.MARKDOWN
+    "csv" -> OpenPreset.CSV
+    "json" -> OpenPreset.JSON
+    "xml" -> OpenPreset.XML
+    "svg" -> OpenPreset.SVG
+    "gif" -> OpenPreset.GIF
+    "jpg", "jpeg", "png", "webp", "bmp", "heic", "heif", "avif" -> OpenPreset.IMAGE
+    "mp4", "mkv", "webm", "avi", "mov", "m4v", "3gp" -> OpenPreset.VIDEO
+    "mp3", "m4a", "aac", "flac", "wav", "ogg", "opus" -> OpenPreset.AUDIO
+    "txt", "log", "ini", "conf", "cfg" -> OpenPreset.TEXT
+    "zip", "rar", "7z", "tar", "gz", "gzip", "tgz", "bz2", "xz" -> OpenPreset.ARCHIVE
+    else -> null
 }
 
 fun ComponentCandidate.matchesOpenPreset(
     preset: OpenPreset,
-    customDefinitions: Map<OpenPreset, CustomOpenDefinition> = emptyMap()
+    customDefinitions: Map<OpenPreset, CustomOpenDefinition> = CustomOpenRegistry.snapshot()
 ): Boolean {
     if (preset == OpenPreset.BROWSER || rule.kind != IntentKind.OPEN) return false
     return evidence.any { line ->

--- a/app/src/main/java/com/yagay/ListCleaner/domain/DefaultOpenConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/DefaultOpenConfig.kt
@@ -1,0 +1,100 @@
+package com.yagay.ListCleaner.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class OpenPreset(val title: String, val description: String) {
+    BROWSER("网页链接", "http / https 链接"),
+    PDF("PDF", "application/pdf"),
+    WORD("Word", "DOC / DOCX"),
+    EXCEL("Excel", "XLS / XLSX"),
+    POWERPOINT("PowerPoint", "PPT / PPTX"),
+    EPUB("电子书", "EPUB"),
+    APK("Android 安装包", "APK"),
+    TORRENT("BT 种子", ".torrent"),
+    MARKDOWN("Markdown", "text/markdown"),
+    CSV("CSV", "text/csv"),
+    JSON("JSON", "application/json"),
+    XML("XML", "application/xml / text/xml"),
+    SVG("SVG", "image/svg+xml"),
+    GIF("GIF", "image/gif"),
+    IMAGE("图片", "image/*"),
+    VIDEO("视频", "video/*"),
+    AUDIO("音频", "audio/*"),
+    TEXT("文本", "text/*"),
+    ARCHIVE("压缩包", "ZIP / RAR / 7Z / TAR / GZIP"),
+    MAGNET("磁力链接", "magnet:"),
+    GEO("地图位置", "geo:"),
+    MAILTO("邮件链接", "mailto:"),
+    TEL("电话链接", "tel:"),
+    SMS("短信链接", "sms: / smsto:")
+}
+
+@Serializable
+data class DefaultOpenConfig(
+    val preferred: Map<OpenPreset, String> = emptyMap()
+) {
+    fun validated(): DefaultOpenConfig {
+        require(preferred.size <= OpenPreset.entries.size)
+        preferred.forEach { (preset, id) ->
+            val rule = requireNotNull(ComponentRule.fromId(id)) { "默认打开组件无效" }
+            require(rule.id == id) { "默认打开组件必须使用规范化类名" }
+            require(if (preset == OpenPreset.BROWSER) rule.kind == IntentKind.BROWSER else rule.kind == IntentKind.OPEN) {
+                "默认打开组件分类不匹配"
+            }
+        }
+        return this
+    }
+}
+
+fun matchOpenPreset(kind: IntentKind, mimeType: String?, scheme: String?): OpenPreset? {
+    val normalizedScheme = scheme?.lowercase()
+    if (kind == IntentKind.BROWSER && normalizedScheme in setOf("http", "https")) return OpenPreset.BROWSER
+    if (kind != IntentKind.OPEN) return null
+
+    when (normalizedScheme) {
+        "magnet" -> return OpenPreset.MAGNET
+        "geo" -> return OpenPreset.GEO
+        "mailto" -> return OpenPreset.MAILTO
+        "tel" -> return OpenPreset.TEL
+        "sms", "smsto" -> return OpenPreset.SMS
+    }
+
+    val mime = mimeType?.substringBefore(';')?.trim()?.lowercase().orEmpty()
+    return when {
+        mime == "application/pdf" -> OpenPreset.PDF
+        mime in setOf("application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") -> OpenPreset.WORD
+        mime in setOf("application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") -> OpenPreset.EXCEL
+        mime in setOf("application/vnd.ms-powerpoint", "application/vnd.openxmlformats-officedocument.presentationml.presentation") -> OpenPreset.POWERPOINT
+        mime == "application/epub+zip" -> OpenPreset.EPUB
+        mime == "application/vnd.android.package-archive" -> OpenPreset.APK
+        mime == "application/x-bittorrent" -> OpenPreset.TORRENT
+        mime in setOf("text/markdown", "text/x-markdown") -> OpenPreset.MARKDOWN
+        mime in setOf("text/csv", "application/csv") -> OpenPreset.CSV
+        mime in setOf("application/json", "text/json") || mime.endsWith("+json") -> OpenPreset.JSON
+        // SVG is XML-based, so it must beat the generic +xml rule.
+        mime == "image/svg+xml" -> OpenPreset.SVG
+        mime == "image/gif" -> OpenPreset.GIF
+        mime in setOf("application/xml", "text/xml") || mime.endsWith("+xml") -> OpenPreset.XML
+        mime.startsWith("image/") -> OpenPreset.IMAGE
+        mime.startsWith("video/") -> OpenPreset.VIDEO
+        mime.startsWith("audio/") -> OpenPreset.AUDIO
+        mime.startsWith("text/") -> OpenPreset.TEXT
+        mime in setOf(
+            "application/zip", "application/x-zip-compressed", "application/x-rar-compressed",
+            "application/vnd.rar", "application/x-7z-compressed", "application/x-tar",
+            "application/gzip", "application/x-gzip"
+        ) -> OpenPreset.ARCHIVE
+        else -> null
+    }
+}
+
+/** Uses scan evidence so the rules/sort pages only show components that actually matched this preset probe. */
+fun ComponentCandidate.matchesOpenPreset(preset: OpenPreset): Boolean {
+    if (preset == OpenPreset.BROWSER || rule.kind != IntentKind.OPEN) return false
+    return evidence.any { line ->
+        val mime = Regex("(?:^|\\s)mime=([^\\s]+)").find(line)?.groupValues?.getOrNull(1)
+        val scheme = Regex("(?:^|\\s)scheme=([^\\s]+)").find(line)?.groupValues?.getOrNull(1)
+        matchOpenPreset(IntentKind.OPEN, mime, scheme) == preset
+    }
+}

--- a/app/src/main/java/com/yagay/ListCleaner/domain/DefaultOpenConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/DefaultOpenConfig.kt
@@ -47,7 +47,19 @@ data class DefaultOpenConfig(
     }
 }
 
-fun matchOpenPreset(kind: IntentKind, mimeType: String?, scheme: String?): OpenPreset? {
+/**
+ * Classifies a resolver request into one of the typed OPEN buckets.
+ *
+ * MIME/scheme remains authoritative. [fileNameOrPath] is only used as a compatibility fallback
+ * for file managers that send no MIME, `*/*`, or an opaque binary MIME such as
+ * `application/octet-stream` (ES File Explorer and similar apps may do this for some files).
+ */
+fun matchOpenPreset(
+    kind: IntentKind,
+    mimeType: String?,
+    scheme: String?,
+    fileNameOrPath: String? = null
+): OpenPreset? {
     val normalizedScheme = scheme?.lowercase()
     if (kind == IntentKind.BROWSER && normalizedScheme in setOf("http", "https")) return OpenPreset.BROWSER
     if (kind != IntentKind.OPEN) return null
@@ -61,7 +73,7 @@ fun matchOpenPreset(kind: IntentKind, mimeType: String?, scheme: String?): OpenP
     }
 
     val mime = mimeType?.substringBefore(';')?.trim()?.lowercase().orEmpty()
-    return when {
+    val mimePreset = when {
         mime == "application/pdf" -> OpenPreset.PDF
         mime in setOf("application/msword", "application/vnd.openxmlformats-officedocument.wordprocessingml.document") -> OpenPreset.WORD
         mime in setOf("application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") -> OpenPreset.EXCEL
@@ -85,6 +97,47 @@ fun matchOpenPreset(kind: IntentKind, mimeType: String?, scheme: String?): OpenP
             "application/vnd.rar", "application/x-7z-compressed", "application/x-tar",
             "application/gzip", "application/x-gzip"
         ) -> OpenPreset.ARCHIVE
+        else -> null
+    }
+    if (mimePreset != null) return mimePreset
+
+    // Do not second-guess a specific, unknown MIME. Extension fallback is deliberately limited to
+    // absent/wildcard/binary MIME values that commonly lose the real file type in file managers.
+    if (mime.isNotEmpty() && mime !in OPAQUE_FILE_MIMES) return null
+    return matchOpenPresetByExtension(fileNameOrPath)
+}
+
+private val OPAQUE_FILE_MIMES = setOf(
+    "*/*",
+    "application/octet-stream",
+    "binary/octet-stream",
+    "application/x-download"
+)
+
+private fun matchOpenPresetByExtension(fileNameOrPath: String?): OpenPreset? {
+    val clean = fileNameOrPath?.trim()?.substringBefore('?')?.substringBefore('#')?.lowercase().orEmpty()
+    if (clean.isEmpty()) return null
+    val extension = clean.substringAfterLast('/', clean).substringAfterLast('.', "")
+    if (extension.isEmpty()) return null
+    return when (extension) {
+        "pdf" -> OpenPreset.PDF
+        "doc", "docx" -> OpenPreset.WORD
+        "xls", "xlsx" -> OpenPreset.EXCEL
+        "ppt", "pptx" -> OpenPreset.POWERPOINT
+        "epub" -> OpenPreset.EPUB
+        "apk", "apks", "xapk" -> OpenPreset.APK
+        "torrent" -> OpenPreset.TORRENT
+        "md", "markdown" -> OpenPreset.MARKDOWN
+        "csv" -> OpenPreset.CSV
+        "json" -> OpenPreset.JSON
+        "xml" -> OpenPreset.XML
+        "svg" -> OpenPreset.SVG
+        "gif" -> OpenPreset.GIF
+        "jpg", "jpeg", "png", "webp", "bmp", "heic", "heif", "avif" -> OpenPreset.IMAGE
+        "mp4", "mkv", "webm", "avi", "mov", "m4v", "3gp" -> OpenPreset.VIDEO
+        "mp3", "m4a", "aac", "flac", "wav", "ogg", "opus" -> OpenPreset.AUDIO
+        "txt", "log", "ini", "conf", "cfg" -> OpenPreset.TEXT
+        "zip", "rar", "7z", "tar", "gz", "gzip", "tgz", "bz2", "xz" -> OpenPreset.ARCHIVE
         else -> null
     }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/domain/DefaultOpenConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/DefaultOpenConfig.kt
@@ -51,7 +51,7 @@ data class DefaultOpenConfig(
  * Classifies a resolver request into one of the typed OPEN buckets.
  *
  * MIME/scheme remains authoritative. [fileNameOrPath] is only used as a compatibility fallback
- * for file managers that send no MIME, `*/*`, or an opaque binary MIME such as
+ * for file managers that send no MIME, a wildcard MIME, or an opaque binary MIME such as
  * `application/octet-stream` (ES File Explorer and similar apps may do this for some files).
  */
 fun matchOpenPreset(

--- a/app/src/main/java/com/yagay/ListCleaner/domain/ModuleConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/ModuleConfig.kt
@@ -1,6 +1,7 @@
 package com.yagay.ListCleaner.domain
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /** One remote preference value prevents mixed old/new fields during backup restore. */
 @Serializable
@@ -11,9 +12,13 @@ data class ModuleConfig(
     val diagnostic: Boolean,
     // Supplied by our own app via framework-owned remote preferences, never by an Intent extra.
     val managerAppId: Int = -1,
+    /** Source-compatibility only. Never serialized or consumed by current runtime behavior. */
+    @Transient val tiles: TileConfig = TileConfig(),
     // Apps in this list are callers from which selected OPEN target packages will be hidden at system_server.
     // They do NOT need to be added to the LSPosed module scope.
     val hiddenFromApps: Set<String> = emptySet(),
+    /** Source-compatibility only. Never serialized or consumed by current runtime behavior. */
+    @Transient val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
     val openTypes: OpenTypeConfig = OpenTypeConfig()
 ) {
     fun validated(): ModuleConfig {

--- a/app/src/main/java/com/yagay/ListCleaner/domain/ModuleConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/ModuleConfig.kt
@@ -14,7 +14,9 @@ data class ModuleConfig(
     val tiles: TileConfig = TileConfig(),
     // Apps in this list are callers from which selected target packages will be hidden at system_server.
     // They do NOT need to be added to the LSPosed module scope.
-    val hiddenFromApps: Set<String> = emptySet()
+    val hiddenFromApps: Set<String> = emptySet(),
+    val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
+    val openTypes: OpenTypeConfig = OpenTypeConfig()
 ) {
     fun validated(): ModuleConfig {
         require(rules.size <= 20_000 && rules.all(ComponentRule::isValid))
@@ -22,6 +24,8 @@ data class ModuleConfig(
         tiles.validated()
         require(managerAppId == -1 || ManagerIdentity.valid(managerAppId))
         require(hiddenFromApps.size <= 2_000 && hiddenFromApps.all(::validPackageName))
+        defaultOpen.validated()
+        openTypes.validated()
         return this
     }
 

--- a/app/src/main/java/com/yagay/ListCleaner/domain/ModuleConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/ModuleConfig.kt
@@ -11,20 +11,16 @@ data class ModuleConfig(
     val diagnostic: Boolean,
     // Supplied by our own app via framework-owned remote preferences, never by an Intent extra.
     val managerAppId: Int = -1,
-    val tiles: TileConfig = TileConfig(),
-    // Apps in this list are callers from which selected target packages will be hidden at system_server.
+    // Apps in this list are callers from which selected OPEN target packages will be hidden at system_server.
     // They do NOT need to be added to the LSPosed module scope.
     val hiddenFromApps: Set<String> = emptySet(),
-    val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
     val openTypes: OpenTypeConfig = OpenTypeConfig()
 ) {
     fun validated(): ModuleConfig {
         require(rules.size <= 20_000 && rules.all(ComponentRule::isValid))
         priorities.validated()
-        tiles.validated()
         require(managerAppId == -1 || ManagerIdentity.valid(managerAppId))
         require(hiddenFromApps.size <= 2_000 && hiddenFromApps.all(::validPackageName))
-        defaultOpen.validated()
         openTypes.validated()
         return this
     }

--- a/app/src/main/java/com/yagay/ListCleaner/domain/ModuleConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/ModuleConfig.kt
@@ -14,12 +14,14 @@ data class ModuleConfig(
     val managerAppId: Int = -1,
     /** Source-compatibility only. Never serialized or consumed by current runtime behavior. */
     @Transient val tiles: TileConfig = TileConfig(),
-    // Apps in this list are callers from which selected OPEN target packages will be hidden at system_server.
+    // Apps in this list are callers from which selected target packages may be hidden at system_server.
     // They do NOT need to be added to the LSPosed module scope.
     val hiddenFromApps: Set<String> = emptySet(),
     /** Source-compatibility only. Never serialized or consumed by current runtime behavior. */
     @Transient val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
-    val openTypes: OpenTypeConfig = OpenTypeConfig()
+    val openTypes: OpenTypeConfig = OpenTypeConfig(),
+    /** Empty by default. Only explicitly selected categories contribute fully-selected package targets. */
+    val visibilityCompat: VisibilityCompatConfig = VisibilityCompatConfig()
 ) {
     fun validated(): ModuleConfig {
         require(rules.size <= 20_000 && rules.all(ComponentRule::isValid))
@@ -27,6 +29,7 @@ data class ModuleConfig(
         require(managerAppId == -1 || ManagerIdentity.valid(managerAppId))
         require(hiddenFromApps.size <= 2_000 && hiddenFromApps.all(::validPackageName))
         openTypes.validated()
+        visibilityCompat.validated()
         return this
     }
 

--- a/app/src/main/java/com/yagay/ListCleaner/domain/OpenEffectPreview.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/OpenEffectPreview.kt
@@ -1,0 +1,72 @@
+package com.yagay.ListCleaner.domain
+
+data class OpenPreviewItem(
+    val candidate: ComponentCandidate,
+    val selected: Boolean,
+    val selectedBy: String?,
+    val included: Boolean,
+    val rank: Int?
+)
+
+data class OpenEffectPreview(
+    val preset: OpenPreset?,
+    val rawCount: Int,
+    val finalCount: Int,
+    val restoredEmpty: Boolean,
+    val items: List<OpenPreviewItem>
+)
+
+/**
+ * Local approximation of the resolver result after List Cleaner rules are applied.
+ * It intentionally does not model caller-UID same-app protection or vendor-private menus.
+ */
+fun previewOpenEffect(
+    candidates: List<ComponentCandidate>,
+    genericSelected: Set<ComponentRule>,
+    mode: DisplayMode,
+    priorities: PriorityConfig,
+    openTypes: OpenTypeConfig,
+    mimeType: String?,
+    scheme: String?,
+    fileNameOrPath: String?
+): OpenEffectPreview {
+    val preset = matchOpenPreset(IntentKind.OPEN, mimeType, scheme, fileNameOrPath)
+    val genericIds = genericSelected.asSequence().filter { it.kind == IntentKind.OPEN }.map { it.id }.toSet()
+    val typedIds = preset?.let { openTypes.rules[it].orEmpty() }.orEmpty()
+    val hasSelection = genericIds.isNotEmpty() || typedIds.isNotEmpty()
+
+    val raw = candidates.filter { it.rule.kind == IntentKind.OPEN }
+    val initiallyIncluded = raw.filter { candidate ->
+        val selected = candidate.rule.id in genericIds || candidate.rule.id in typedIds
+        mode.includes(selected, hasSelection)
+    }
+    val restoredEmpty = FilterPolicy.restoreEmpty(IntentKind.OPEN.name, raw.size, initiallyIncluded.size)
+    val kept = if (restoredEmpty) raw else initiallyIncluded
+
+    val savedPriority = preset?.let { openTypes.priorities[it].orEmpty() }
+        .takeUnless { it.isNullOrEmpty() }
+        ?: priorities.apps[IntentKind.OPEN].orEmpty()
+    val ranks = savedPriority.filter { pkg -> kept.any { it.rule.packageName == pkg } }
+        .mapIndexed { index, pkg -> pkg to index + 1 }.toMap()
+
+    val keptIds = kept.map { it.rule.id }.toSet()
+    val items = raw.map { candidate ->
+        val inGeneric = candidate.rule.id in genericIds
+        val inTyped = candidate.rule.id in typedIds
+        OpenPreviewItem(
+            candidate = candidate,
+            selected = inGeneric || inTyped,
+            selectedBy = when {
+                inGeneric && inTyped -> "全部 + ${preset?.title ?: "分类型"}"
+                inGeneric -> "全部"
+                inTyped -> preset?.title ?: "分类型"
+                else -> null
+            },
+            included = candidate.rule.id in keptIds,
+            rank = ranks[candidate.rule.packageName]
+        )
+    }.sortedWith(compareBy<OpenPreviewItem>({ if (it.included) 0 else 1 }, { it.rank ?: Int.MAX_VALUE },
+        { it.candidate.appLabel.lowercase() }, { it.candidate.rule.id }))
+
+    return OpenEffectPreview(preset, raw.size, kept.size, restoredEmpty, items)
+}

--- a/app/src/main/java/com/yagay/ListCleaner/domain/OpenEffectPreview.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/OpenEffectPreview.kt
@@ -30,7 +30,7 @@ fun previewOpenEffect(
     scheme: String?,
     fileNameOrPath: String?
 ): OpenEffectPreview {
-    val preset = matchOpenPreset(IntentKind.OPEN, mimeType, scheme, fileNameOrPath)
+    val preset = matchOpenPreset(IntentKind.OPEN, mimeType, scheme, fileNameOrPath, openTypes.customDefinitions)
     val genericIds = genericSelected.asSequence().filter { it.kind == IntentKind.OPEN }.map { it.id }.toSet()
     val typedIds = preset?.let { openTypes.rules[it].orEmpty() }.orEmpty()
     val hasSelection = genericIds.isNotEmpty() || typedIds.isNotEmpty()
@@ -57,9 +57,9 @@ fun previewOpenEffect(
             candidate = candidate,
             selected = inGeneric || inTyped,
             selectedBy = when {
-                inGeneric && inTyped -> "全部 + ${preset?.title ?: "分类型"}"
+                inGeneric && inTyped -> "全部 + ${preset?.let(openTypes::titleFor) ?: "分类型"}"
                 inGeneric -> "全部"
-                inTyped -> preset?.title ?: "分类型"
+                inTyped -> preset?.let(openTypes::titleFor) ?: "分类型"
                 else -> null
             },
             included = candidate.rule.id in keptIds,

--- a/app/src/main/java/com/yagay/ListCleaner/domain/OpenTypeConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/OpenTypeConfig.kt
@@ -2,15 +2,55 @@ package com.yagay.ListCleaner.domain
 
 import kotlinx.serialization.Serializable
 
+@Serializable
+data class CustomOpenDefinition(
+    val title: String,
+    val mimeTypes: Set<String> = emptySet(),
+    val extensions: Set<String> = emptySet()
+) {
+    fun validated(): CustomOpenDefinition {
+        val cleanTitle = title.trim()
+        require(cleanTitle.isNotEmpty() && cleanTitle.length <= 24 && cleanTitle.none { it.isISOControl() }) { "自定义类型名称无效" }
+        require(mimeTypes.size <= 24 && mimeTypes.all(::validMime)) { "自定义 MIME 无效" }
+        require(extensions.size <= 48 && extensions.all(::validExtension)) { "自定义文件后缀无效" }
+        require(mimeTypes.isNotEmpty() || extensions.isNotEmpty()) { "自定义类型至少需要一个 MIME 或文件后缀" }
+        return copy(
+            title = cleanTitle,
+            mimeTypes = mimeTypes.map { it.trim().lowercase() }.toSet(),
+            extensions = extensions.map { it.trim().removePrefix(".").lowercase() }.toSet()
+        )
+    }
+
+    private fun validMime(value: String): Boolean {
+        val mime = value.trim().lowercase()
+        if (mime.length !in 3..127 || '/' !in mime || mime.any { it.isWhitespace() || it.isISOControl() }) return false
+        val (type, subtype) = mime.split('/', limit = 2).let { it[0] to it[1] }
+        return type.isNotEmpty() && subtype.isNotEmpty() && '*' !in type && (subtype == "*" || '*' !in subtype)
+    }
+
+    private fun validExtension(value: String): Boolean {
+        val ext = value.trim().removePrefix(".").lowercase()
+        return ext.length in 1..24 && ext.all { it.isLetterOrDigit() || it in setOf('_', '-') }
+    }
+}
+
 /** Per-open-type rules and ordering. Generic OPEN rules/priorities remain the fallback. */
 @Serializable
 data class OpenTypeConfig(
     val rules: Map<OpenPreset, Set<String>> = emptyMap(),
-    val priorities: Map<OpenPreset, List<String>> = emptyMap()
+    val priorities: Map<OpenPreset, List<String>> = emptyMap(),
+    val customDefinitions: Map<OpenPreset, CustomOpenDefinition> = emptyMap()
 ) {
     fun validated(): OpenTypeConfig {
         require(OpenPreset.BROWSER !in rules && OpenPreset.BROWSER !in priorities) { "浏览器不属于打开方式类型规则" }
         require(rules.size <= OpenPreset.entries.size && priorities.size <= OpenPreset.entries.size)
+        val cleanCustom = customDefinitions.mapValues { (preset, definition) ->
+            require(preset.isCustom) { "自定义定义只能使用自定义类型槽位" }
+            definition.validated()
+        }
+        require(cleanCustom.size <= OpenPreset.CUSTOM_SLOTS.size) { "自定义打开类型过多" }
+        require(rules.keys.filter(OpenPreset::isCustom).all { it in cleanCustom }) { "自定义规则缺少类型定义" }
+        require(priorities.keys.filter(OpenPreset::isCustom).all { it in cleanCustom }) { "自定义排序缺少类型定义" }
         require(rules.values.all { ids ->
             ids.size <= 2_000 && ids.all { id ->
                 val parsed = ComponentRule.fromId(id)
@@ -22,9 +62,14 @@ data class OpenTypeConfig(
                 it.isNotBlank() && it.length <= 255 && '|' !in it && it.none { ch -> ch.isWhitespace() || ch.isISOControl() }
             }
         }) { "打开类型排序配置无效" }
-        return this
+        return if (cleanCustom == customDefinitions) this else copy(customDefinitions = cleanCustom)
     }
 
     fun selectedRules(preset: OpenPreset): Set<ComponentRule> =
         rules[preset].orEmpty().mapNotNull(ComponentRule::fromId).toSet()
+
+    fun titleFor(preset: OpenPreset): String = customDefinitions[preset]?.title ?: preset.title
+
+    fun configuredPresets(): List<OpenPreset> =
+        OpenPreset.entries.filter { it != OpenPreset.BROWSER && (!it.isCustom || it in customDefinitions) }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/domain/OpenTypeConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/OpenTypeConfig.kt
@@ -1,0 +1,30 @@
+package com.yagay.ListCleaner.domain
+
+import kotlinx.serialization.Serializable
+
+/** Per-open-type rules and ordering. Generic OPEN rules/priorities remain the fallback. */
+@Serializable
+data class OpenTypeConfig(
+    val rules: Map<OpenPreset, Set<String>> = emptyMap(),
+    val priorities: Map<OpenPreset, List<String>> = emptyMap()
+) {
+    fun validated(): OpenTypeConfig {
+        require(OpenPreset.BROWSER !in rules && OpenPreset.BROWSER !in priorities) { "浏览器不属于打开方式类型规则" }
+        require(rules.size <= OpenPreset.entries.size && priorities.size <= OpenPreset.entries.size)
+        require(rules.values.all { ids ->
+            ids.size <= 2_000 && ids.all { id ->
+                val parsed = ComponentRule.fromId(id)
+                parsed != null && parsed.id == id && parsed.kind == IntentKind.OPEN
+            }
+        }) { "打开类型规则无效" }
+        require(priorities.values.all { packages ->
+            packages.size <= 200 && packages.distinct().size == packages.size && packages.all {
+                it.isNotBlank() && it.length <= 255 && '|' !in it && it.none { ch -> ch.isWhitespace() || ch.isISOControl() }
+            }
+        }) { "打开类型排序配置无效" }
+        return this
+    }
+
+    fun selectedRules(preset: OpenPreset): Set<ComponentRule> =
+        rules[preset].orEmpty().mapNotNull(ComponentRule::fromId).toSet()
+}

--- a/app/src/main/java/com/yagay/ListCleaner/domain/OpenTypeConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/OpenTypeConfig.kt
@@ -1,6 +1,7 @@
 package com.yagay.ListCleaner.domain
 
 import kotlinx.serialization.Serializable
+import java.util.concurrent.atomic.AtomicReference
 
 @Serializable
 data class CustomOpenDefinition(
@@ -34,6 +35,16 @@ data class CustomOpenDefinition(
     }
 }
 
+/**
+ * Process-local registry used by the four-argument matcher call sites inside the hooked Android
+ * processes. ModuleConfig.validated() refreshes it whenever a new remote snapshot is decoded.
+ */
+object CustomOpenRegistry {
+    private val definitions = AtomicReference<Map<OpenPreset, CustomOpenDefinition>>(emptyMap())
+    fun replace(value: Map<OpenPreset, CustomOpenDefinition>) { definitions.set(value.toMap()) }
+    fun snapshot(): Map<OpenPreset, CustomOpenDefinition> = definitions.get()
+}
+
 /** Per-open-type rules and ordering. Generic OPEN rules/priorities remain the fallback. */
 @Serializable
 data class OpenTypeConfig(
@@ -49,8 +60,8 @@ data class OpenTypeConfig(
             definition.validated()
         }
         require(cleanCustom.size <= OpenPreset.CUSTOM_SLOTS.size) { "自定义打开类型过多" }
-        require(rules.keys.filter(OpenPreset::isCustom).all { it in cleanCustom }) { "自定义规则缺少类型定义" }
-        require(priorities.keys.filter(OpenPreset::isCustom).all { it in cleanCustom }) { "自定义排序缺少类型定义" }
+        require(rules.keys.filter { it.isCustom }.all { it in cleanCustom }) { "自定义规则缺少类型定义" }
+        require(priorities.keys.filter { it.isCustom }.all { it in cleanCustom }) { "自定义排序缺少类型定义" }
         require(rules.values.all { ids ->
             ids.size <= 2_000 && ids.all { id ->
                 val parsed = ComponentRule.fromId(id)
@@ -62,6 +73,7 @@ data class OpenTypeConfig(
                 it.isNotBlank() && it.length <= 255 && '|' !in it && it.none { ch -> ch.isWhitespace() || ch.isISOControl() }
             }
         }) { "打开类型排序配置无效" }
+        CustomOpenRegistry.replace(cleanCustom)
         return if (cleanCustom == customDefinitions) this else copy(customDefinitions = cleanCustom)
     }
 

--- a/app/src/main/java/com/yagay/ListCleaner/domain/PriorityList.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/PriorityList.kt
@@ -11,9 +11,10 @@ data class PriorityAppGroup(
 /** Priority apps lead in saved order; remaining apps use their default alphabetic order. */
 fun priorityAppGroups(
     candidates: List<ComponentCandidate>, selected: Set<ComponentRule>, mode: DisplayMode,
-    kind: IntentKind, saved: List<String>, query: String, filter: PriorityListFilter
+    kind: IntentKind, saved: List<String>, query: String, filter: PriorityListFilter,
+    extraSelected: Set<ComponentRule> = emptySet()
 ): List<PriorityAppGroup> {
-    val apps = priorityCandidates(candidates, selected, mode, kind).groupBy { it.rule.packageName }
+    val apps = priorityCandidates(candidates, selected, mode, kind, extraSelected).groupBy { it.rule.packageName }
     val ranks = saved.filter { it in apps }.mapIndexed { index, pkg -> pkg to index + 1 }.toMap()
     val groups = apps.mapNotNull { (pkg, components) ->
         val rank = ranks[pkg]

--- a/app/src/main/java/com/yagay/ListCleaner/domain/PriorityVisibility.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/PriorityVisibility.kt
@@ -2,11 +2,13 @@ package com.yagay.ListCleaner.domain
 
 /** Same category and rule mode as filtering. A partially hidden app keeps surviving entries. */
 fun priorityCandidates(
-    candidates: List<ComponentCandidate>, selected: Set<ComponentRule>, mode: DisplayMode, kind: IntentKind
+    candidates: List<ComponentCandidate>, selected: Set<ComponentRule>, mode: DisplayMode, kind: IntentKind,
+    extraSelected: Set<ComponentRule> = emptySet()
 ): List<ComponentCandidate> {
-    val hasSelection = selected.any { it.kind == kind }
+    val effectiveSelected = selected + extraSelected
+    val hasSelection = effectiveSelected.any { it.kind == kind }
     return candidates.filter {
-        it.rule.kind == kind && it.isCatalogCandidate && mode.includes(it.rule in selected, hasSelection)
+        it.rule.kind == kind && it.isCatalogCandidate && mode.includes(it.rule in effectiveSelected, hasSelection)
     }
 }
 

--- a/app/src/main/java/com/yagay/ListCleaner/domain/Rule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/Rule.kt
@@ -67,5 +67,7 @@ data class RuleBackup(
     val hiddenFromApps: Set<String> = emptySet(),
     /** Source-compatibility only. Not written to new backups. */
     @Transient val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
-    val openTypes: OpenTypeConfig = OpenTypeConfig()
+    val openTypes: OpenTypeConfig = OpenTypeConfig(),
+    /** User choice only; derived full-package targets are rebuilt from current catalog/rules. */
+    val visibilityScopes: Set<VisibilityScope> = emptySet()
 )

--- a/app/src/main/java/com/yagay/ListCleaner/domain/Rule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/Rule.kt
@@ -64,5 +64,7 @@ data class RuleBackup(
     val priorities: PriorityConfig = PriorityConfig(),
     val displayMode: DisplayMode? = null,
     val tiles: TileConfig = TileConfig(),
-    val hiddenFromApps: Set<String> = emptySet()
+    val hiddenFromApps: Set<String> = emptySet(),
+    val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
+    val openTypes: OpenTypeConfig = OpenTypeConfig()
 )

--- a/app/src/main/java/com/yagay/ListCleaner/domain/Rule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/Rule.kt
@@ -43,12 +43,10 @@ data class ComponentCandidate(
     val activityLabel: String,
     val appIcon: Bitmap? = null,
     val evidence: List<String> = emptyList(),
-    // Only non-exported foreign components, not raw enabled fields or manager permissions.
     val restricted: Boolean = false,
     val unavailable: Boolean = false,
     val broadMatch: Boolean = false
 ) {
-    // One predicate shared by rules, priority suggestions and diagnostic summaries.
     val isCatalogCandidate: Boolean get() = !unavailable && !restricted
 
     fun matchesQuery(query: String): Boolean = query.isBlank() ||
@@ -63,8 +61,6 @@ data class RuleBackup(
     val rules: Set<ComponentRule>,
     val priorities: PriorityConfig = PriorityConfig(),
     val displayMode: DisplayMode? = null,
-    val tiles: TileConfig = TileConfig(),
     val hiddenFromApps: Set<String> = emptySet(),
-    val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
     val openTypes: OpenTypeConfig = OpenTypeConfig()
 )

--- a/app/src/main/java/com/yagay/ListCleaner/domain/Rule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/Rule.kt
@@ -3,6 +3,7 @@ package com.yagay.ListCleaner.domain
 import android.content.Intent
 import android.graphics.Bitmap
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Serializable
 enum class IntentKind(val action: String, val title: String) {
@@ -61,6 +62,10 @@ data class RuleBackup(
     val rules: Set<ComponentRule>,
     val priorities: PriorityConfig = PriorityConfig(),
     val displayMode: DisplayMode? = null,
+    /** Source-compatibility only. Not written to new backups. */
+    @Transient val tiles: TileConfig = TileConfig(),
     val hiddenFromApps: Set<String> = emptySet(),
+    /** Source-compatibility only. Not written to new backups. */
+    @Transient val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
     val openTypes: OpenTypeConfig = OpenTypeConfig()
 )

--- a/app/src/main/java/com/yagay/ListCleaner/domain/VisibilityCompat.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/VisibilityCompat.kt
@@ -1,0 +1,66 @@
+package com.yagay.ListCleaner.domain
+
+import kotlinx.serialization.Serializable
+
+/** Categories whose fully-selected app rows may contribute package-level visibility hiding. */
+@Serializable
+enum class VisibilityScope(val title: String) {
+    ALL("全部"),
+    SHARE("分享"),
+    SHARE_MULTIPLE("多文件分享"),
+    OPEN("打开方式"),
+    BROWSER("浏览器"),
+    PROCESS_TEXT("文本处理");
+
+    fun matches(kind: IntentKind): Boolean = this == ALL || name == kind.name
+
+    companion object {
+        fun forKind(kind: IntentKind): VisibilityScope = valueOf(kind.name)
+    }
+}
+
+@Serializable
+data class VisibilityCompatConfig(
+    /** User-selected categories. Empty by default: package-level compatibility hiding is disabled. */
+    val scopes: Set<VisibilityScope> = emptySet(),
+    /** Derived by the manager from current catalog + rule state. Partial app selections are excluded. */
+    val fullPackages: Map<VisibilityScope, Set<String>> = emptyMap()
+) {
+    fun validated(): VisibilityCompatConfig {
+        require(fullPackages.size <= VisibilityScope.entries.size)
+        fullPackages.forEach { (scope, packages) ->
+            require(scope != VisibilityScope.ALL) { "ALL is derived from concrete categories" }
+            require(packages.size <= 20_000)
+            require(packages.all(::validPackageName))
+        }
+        return this
+    }
+
+    fun activePackages(): Set<String> {
+        if (scopes.isEmpty()) return emptySet()
+        val concrete = if (VisibilityScope.ALL in scopes) {
+            VisibilityScope.entries.filter { it != VisibilityScope.ALL }
+        } else scopes.filter { it != VisibilityScope.ALL }
+        return concrete.asSequence().flatMap { fullPackages[it].orEmpty().asSequence() }.toSet()
+    }
+
+    private fun validPackageName(value: String): Boolean =
+        value.isNotBlank() && value.length <= 255 && value.none { it.isWhitespace() || it.isISOControl() || it == '|' }
+}
+
+/**
+ * An app is eligible for package-level compatibility hiding only when every currently catalogued
+ * component in that top-level category is selected. This intentionally rejects tri-state/partial rows.
+ */
+fun deriveFullySelectedPackages(
+    candidates: List<ComponentCandidate>,
+    selected: Set<ComponentRule>
+): Map<VisibilityScope, Set<String>> = IntentKind.entries.associate { kind ->
+    val packages = candidates.asSequence()
+        .filter { it.isCatalogCandidate && it.rule.kind == kind }
+        .groupBy { it.rule.packageName }
+        .filterValues { items -> items.isNotEmpty() && items.all { it.rule in selected } }
+        .keys
+        .toSet()
+    VisibilityScope.forKind(kind) to packages
+}.filterValues { it.isNotEmpty() }

--- a/app/src/main/java/com/yagay/ListCleaner/ui/AppListRows.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/AppListRows.kt
@@ -27,8 +27,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TriStateCheckbox
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,143 +38,153 @@ import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-
-import androidx.compose.material3.*
-import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.rounded.Apps
 import com.yagay.ListCleaner.domain.ComponentCandidate
-import com.yagay.ListCleaner.domain.ComponentRule
-    @Composable
-    internal fun AppRow(group: AppGroup, selected: Set<com.yagay.ListCleaner.domain.ComponentRule>, expanded: Boolean, onExpand: () -> Unit, onSelect: (Boolean) -> Unit) {
-        val selectedCount = group.components.count { it.rule in selected }
-        val selectionState = when {
-            selectedCount == 0 -> ToggleableState.Off
-            selectedCount == group.components.size -> ToggleableState.On
-            else -> ToggleableState.Indeterminate
-        }
-        Row(
-            modifier = Modifier.fillMaxWidth()
-                .clickable(onClickLabel = if (expanded) "折叠" else "展开", onClick = onExpand)
-                .heightIn(min = 64.dp)
-                .padding(horizontal = 8.dp, vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            TriStateCheckbox(
-                state = selectionState,
-                onClick = { onSelect(selectionState != ToggleableState.On) }
+
+@Composable
+internal fun AppRow(group: AppGroup, selected: Set<com.yagay.ListCleaner.domain.ComponentRule>, expanded: Boolean, onExpand: () -> Unit, onSelect: (Boolean) -> Unit) {
+    val selectedCount = group.components.count { it.rule in selected }
+    val selectionState = when {
+        selectedCount == 0 -> ToggleableState.Off
+        selectedCount == group.components.size -> ToggleableState.On
+        else -> ToggleableState.Indeterminate
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth()
+            .clickable(onClickLabel = if (expanded) "折叠" else "展开", onClick = onExpand)
+            .heightIn(min = 64.dp)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        TriStateCheckbox(
+            state = selectionState,
+            onClick = { onSelect(selectionState != ToggleableState.On) }
+        )
+        AppIcon(bitmap = group.appIcon, appLabel = group.appLabel)
+        Column(Modifier.weight(1f).padding(start = 10.dp)) {
+            Text(
+                group.appLabel,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                fontWeight = FontWeight.Medium
             )
-            AppIcon(bitmap = group.appIcon, appLabel = group.appLabel)
-            Column(Modifier.weight(1f).padding(start = 10.dp)) {
+            Text(
+                "已选 $selectedCount/${group.components.size} · ${group.components.map { it.rule.kind.shortTitle }.distinct().joinToString("、")}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            val missing = group.components.count { it.unavailable || it.restricted }
+            if (missing > 0) Text("含 $missing 条当前不可用规则", style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.error)
+        }
+        IconButton(onClick = onExpand) {
+            Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, if (expanded) "折叠" else "展开")
+        }
+    }
+    HorizontalDivider()
+}
+
+@Composable
+internal fun ComponentRow(
+    item: ComponentCandidate,
+    checked: Boolean,
+    customTitle: String?,
+    selectionNote: String? = null,
+    onToggle: () -> Unit,
+    onEditTitle: () -> Unit
+) {
+    Row(
+        Modifier.fillMaxWidth()
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.25f))
+            .toggleable(
+                value = checked,
+                role = Role.Checkbox,
+                onValueChange = { onToggle() }
+            )
+            .heightIn(min = 48.dp)
+            .padding(start = 24.dp, end = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ComponentSelectionMark(checked)
+        Column(Modifier.weight(1f).padding(vertical = 6.dp)) {
+            Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
                 Text(
-                    group.appLabel,
+                    item.activityLabel,
+                    modifier = Modifier.weight(1f).padding(end = 12.dp),
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    fontWeight = FontWeight.Medium
+                    overflow = TextOverflow.Ellipsis
                 )
                 Text(
-                    "已选 $selectedCount/${group.components.size} · ${group.components.map { it.rule.kind.shortTitle }.distinct().joinToString("、")}",
-                    style = MaterialTheme.typography.bodySmall,
+                    item.rule.kind.shortTitle,
+                    style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-                val missing = group.components.count { it.unavailable || it.restricted }
-                if (missing > 0) Text("含 $missing 条当前不可用规则", style = MaterialTheme.typography.labelSmall,
-                    color = MaterialTheme.colorScheme.error)
             }
-            IconButton(onClick = onExpand) {
-                Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, if (expanded) "折叠" else "展开")
+            selectionNote?.let {
+                Text(
+                    it,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
+            if (!customTitle.isNullOrBlank()) Text(
+                "显示为：$customTitle",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Text(
+                item.rule.className,
+                modifier = Modifier.padding(top = 2.dp),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (item.unavailable) Text("当前未找到组件 · 可取消规则", style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.error)
+            else if (item.restricted) Text("非公开组件 · 可取消已有规则", style = MaterialTheme.typography.labelSmall)
         }
-        HorizontalDivider()
+        IconButton(onClick = onEditTitle) {
+            Icon(Icons.Rounded.Edit, contentDescription = "修改显示名称")
+        }
     }
+}
 
-    @Composable
-    internal fun ComponentRow(item: ComponentCandidate, checked: Boolean, customTitle: String?, onToggle: () -> Unit, onEditTitle: () -> Unit) {
-
-            Row(
-                Modifier.fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.25f))
-                    .toggleable(
-                        value = checked,
-                        role = Role.Checkbox,
-                        onValueChange = { onToggle() }
-                    )
-                    .heightIn(min = 48.dp)
-                    .padding(start = 24.dp, end = 16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                ComponentSelectionMark(checked)
-                Column(Modifier.weight(1f).padding(vertical = 6.dp)) {
-                    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            item.activityLabel,
-                            modifier = Modifier.weight(1f).padding(end = 12.dp),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            item.rule.kind.shortTitle,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                    if (!customTitle.isNullOrBlank()) Text(
-                        "显示为：$customTitle",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.primary,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        item.rule.className,
-                        modifier = Modifier.padding(top = 2.dp),
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    if (item.unavailable) Text("当前未找到组件 · 可取消规则", style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.error)
-                    else if (item.restricted) Text("非公开组件 · 可取消已有规则", style = MaterialTheme.typography.labelSmall)
-                }
-                IconButton(onClick = onEditTitle) {
-                    Icon(Icons.Rounded.Edit, contentDescription = "修改显示名称")
-                }
-            }
-        }
-
-
-    @Composable
-    private fun ComponentSelectionMark(checked: Boolean) {
-        val colors = MaterialTheme.colorScheme
-        // The parent row owns the checkbox semantics and the full touch target.
-        Box(Modifier.size(48.dp), contentAlignment = Alignment.Center) {
-            Box(
-                Modifier.size(20.dp)
-                    .background(if (checked) colors.primary else Color.Transparent, CircleShape)
-                    .border(1.5.dp, if (checked) colors.primary else colors.outline, CircleShape),
-                contentAlignment = Alignment.Center
-            ) {
-                if (checked) {
-                    Icon(Icons.Rounded.Check, contentDescription = null, modifier = Modifier.size(14.dp), tint = colors.onPrimary)
-                }
+@Composable
+private fun ComponentSelectionMark(checked: Boolean) {
+    val colors = MaterialTheme.colorScheme
+    Box(Modifier.size(48.dp), contentAlignment = Alignment.Center) {
+        Box(
+            Modifier.size(20.dp)
+                .background(if (checked) colors.primary else Color.Transparent, CircleShape)
+                .border(1.5.dp, if (checked) colors.primary else colors.outline, CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            if (checked) {
+                Icon(Icons.Rounded.Check, contentDescription = null, modifier = Modifier.size(14.dp), tint = colors.onPrimary)
             }
         }
     }
+}
 
-    @Composable
-    internal fun AppIcon(bitmap: Bitmap?, appLabel: String) {
-        if (bitmap == null) {
-            Icon(Icons.Rounded.Apps, null, Modifier.size(40.dp))
-            return
-        }
-        Image(
-            bitmap = bitmap.asImageBitmap(),
-            contentDescription = "$appLabel 图标",
-            modifier = Modifier.size(40.dp).clip(RoundedCornerShape(9.dp)),
-            contentScale = ContentScale.Fit
-        )
+@Composable
+internal fun AppIcon(bitmap: Bitmap?, appLabel: String) {
+    if (bitmap == null) {
+        Icon(Icons.Rounded.Apps, null, Modifier.size(40.dp))
+        return
     }
+    Image(
+        bitmap = bitmap.asImageBitmap(),
+        contentDescription = "$appLabel 图标",
+        modifier = Modifier.size(40.dp).clip(RoundedCornerShape(9.dp)),
+        contentScale = ContentScale.Fit
+    )
+}

--- a/app/src/main/java/com/yagay/ListCleaner/ui/AppScopePicker.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/AppScopePicker.kt
@@ -95,7 +95,7 @@ internal fun AppScopePickerDialog(
         ) { padding ->
             Column(Modifier.fillMaxSize().padding(padding).padding(horizontal = 12.dp)) {
                 Text(
-                    "这里选择的是“从哪些应用中隐藏规则目标”。仅在“隐藏选中”模式生效；这些应用不需要加入 LSPosed Hook 作用域，List Cleaner 只在 system/system_server 侧应用包级隐藏。列表显示完整已安装应用，并显示应用图标。勾选立即保存。",
+                    "这里选择的是“哪些来源应用需要打开方式兼容隐藏”。仅在“隐藏选中”模式生效；目标范围只跟随“打开方式”通用规则和 PDF、APK、视频等分类型 OPEN 规则，不再因为分享或文本处理规则而隐藏整个目标应用。该功能仍是 system/system_server 侧的包级隐藏，适合 ES 等自己查询应用列表的文件管理器。勾选立即保存。",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/com/yagay/ListCleaner/ui/AppScopePicker.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/AppScopePicker.kt
@@ -78,12 +78,16 @@ internal fun AppScopePickerDialog(
         loading = false
     }
 
-    val visible = remember(apps, query, showSystem) {
+    val visible = remember(apps, query, showSystem, selected) {
         val needle = query.trim().lowercase()
         apps.filter { entry ->
             (showSystem || !entry.system) &&
                 (needle.isEmpty() || entry.label.lowercase().contains(needle) || entry.packageName.lowercase().contains(needle))
-        }
+        }.sortedWith(
+            compareBy<ScopeAppEntry> { if (it.packageName in selected) 0 else 1 }
+                .thenBy { it.label.lowercase() }
+                .thenBy { it.packageName }
+        )
     }
     val activeTargets = remember(visibilityScopes, fullPackages) {
         com.yagay.ListCleaner.domain.VisibilityCompatConfig(visibilityScopes, fullPackages).activePackages()

--- a/app/src/main/java/com/yagay/ListCleaner/ui/AppScopePicker.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/AppScopePicker.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
@@ -21,6 +22,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.graphics.drawable.toBitmap
+import com.yagay.ListCleaner.ListCleanerApp
+import com.yagay.ListCleaner.domain.VisibilityScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -62,6 +65,9 @@ internal fun AppScopePickerDialog(
     dismiss: () -> Unit,
 ) {
     val context = LocalContext.current
+    val app = context.applicationContext as ListCleanerApp
+    val visibilityScopes by app.rules.visibilityScopes.collectAsState()
+    val fullPackages by app.rules.visibilityFullPackages.collectAsState()
     var query by remember { mutableStateOf("") }
     var showSystem by remember { mutableStateOf(true) }
     var apps by remember { mutableStateOf<List<ScopeAppEntry>>(emptyList()) }
@@ -79,6 +85,9 @@ internal fun AppScopePickerDialog(
                 (needle.isEmpty() || entry.label.lowercase().contains(needle) || entry.packageName.lowercase().contains(needle))
         }
     }
+    val activeTargets = remember(visibilityScopes, fullPackages) {
+        com.yagay.ListCleaner.domain.VisibilityCompatConfig(visibilityScopes, fullPackages).activePackages()
+    }
 
     Dialog(
         onDismissRequest = dismiss,
@@ -95,15 +104,43 @@ internal fun AppScopePickerDialog(
         ) { padding ->
             Column(Modifier.fillMaxSize().padding(padding).padding(horizontal = 12.dp)) {
                 Text(
-                    "这里选择的是“哪些来源应用需要打开方式兼容隐藏”。仅在“隐藏选中”模式生效；目标范围只跟随“打开方式”通用规则和 PDF、APK、视频等分类型 OPEN 规则，不再因为分享或文本处理规则而隐藏整个目标应用。该功能仍是 system/system_server 侧的包级隐藏，适合 ES 等自己查询应用列表的文件管理器。勾选立即保存。",
+                    "这里选择“哪些来源应用”需要包级隐藏兼容。下面的“命中分类”决定哪些规则分类可以贡献目标应用；默认不选择任何分类，因此不会自动启用兼容隐藏。仅在“隐藏选中”模式生效。",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                Spacer(Modifier.height(10.dp))
+                Spacer(Modifier.height(8.dp))
+                Text("命中分类（可多选）", style = MaterialTheme.typography.labelLarge)
+                LazyRow(
+                    contentPadding = PaddingValues(vertical = 4.dp),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    items(VisibilityScope.entries, key = { it.name }) { scope ->
+                        val checked = scope in visibilityScopes
+                        FilterChip(
+                            selected = checked,
+                            onClick = {
+                                app.rules.setVisibilityScopes(
+                                    if (checked) visibilityScopes - scope else visibilityScopes + scope
+                                )
+                            },
+                            label = { Text(scope.title) },
+                        )
+                    }
+                }
+                Text(
+                    if (visibilityScopes.isEmpty()) {
+                        "当前未选择分类：应用隐藏兼容不会隐藏任何目标应用。"
+                    } else {
+                        "只使用所选分类中“应用整行完整勾选”的目标；半勾选（只选部分组件）不加入。当前可命中 ${activeTargets.size} 个目标包。"
+                    },
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
                 OutlinedTextField(
                     value = query,
                     onValueChange = { query = it },
-                    label = { Text("搜索应用或包名") },
+                    label = { Text("搜索来源应用或包名") },
                     singleLine = true,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -112,7 +149,7 @@ internal fun AppScopePickerDialog(
                     Switch(checked = showSystem, onCheckedChange = { showSystem = it })
                 }
                 Text(
-                    "显示 ${visible.size}/${apps.size} 个应用 · 已加入隐藏列表 ${selected.size} 个",
+                    "显示 ${visible.size}/${apps.size} 个来源应用 · 已加入 ${selected.size} 个",
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )

--- a/app/src/main/java/com/yagay/ListCleaner/ui/CustomOpenTypeDialog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/CustomOpenTypeDialog.kt
@@ -1,0 +1,121 @@
+package com.yagay.ListCleaner.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.yagay.ListCleaner.domain.CustomOpenDefinition
+import com.yagay.ListCleaner.domain.OpenPreset
+import com.yagay.ListCleaner.domain.OpenTypeConfig
+
+@Composable
+internal fun CustomOpenTypeDialog(
+    config: OpenTypeConfig,
+    onSave: (OpenPreset, CustomOpenDefinition?) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var editing by remember { mutableStateOf<OpenPreset?>(null) }
+    val preset = editing
+    if (preset != null) {
+        CustomOpenTypeEditor(
+            preset = preset,
+            initial = config.customDefinitions[preset],
+            onSave = { definition -> onSave(preset, definition); editing = null },
+            onDelete = if (preset in config.customDefinitions) ({ onSave(preset, null); editing = null }) else null,
+            onDismiss = { editing = null }
+        )
+        return
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("自定义打开方式类型") },
+        text = {
+            Column(Modifier.fillMaxWidth()) {
+                Text(
+                    "最多 8 个自定义类型。每个类型可以按 MIME 和文件后缀识别，并拥有自己的规则与排序；未设置专用规则/排序时仍继承“打开方式 · 全部”。删除类型会同时清理该类型的专用规则和排序。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Spacer(Modifier.height(8.dp))
+                LazyColumn(Modifier.heightIn(max = 420.dp)) {
+                    items(OpenPreset.CUSTOM_SLOTS, key = { it.name }) { slot ->
+                        val definition = config.customDefinitions[slot]
+                        ListItem(
+                            headlineContent = { Text(definition?.title ?: slot.title, fontWeight = if (definition != null) FontWeight.Medium else FontWeight.Normal) },
+                            supportingContent = {
+                                Text(if (definition == null) "未配置" else buildString {
+                                    if (definition.mimeTypes.isNotEmpty()) append("MIME ${definition.mimeTypes.joinToString()}")
+                                    if (definition.mimeTypes.isNotEmpty() && definition.extensions.isNotEmpty()) append(" · ")
+                                    if (definition.extensions.isNotEmpty()) append("后缀 ${definition.extensions.joinToString { ".$it" }}")
+                                })
+                            },
+                            trailingContent = { TextButton(onClick = { editing = slot }) { Text(if (definition == null) "添加" else "编辑") } }
+                        )
+                        HorizontalDivider()
+                    }
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = onDismiss) { Text("完成") } }
+    )
+}
+
+@Composable
+private fun CustomOpenTypeEditor(
+    preset: OpenPreset,
+    initial: CustomOpenDefinition?,
+    onSave: (CustomOpenDefinition) -> Unit,
+    onDelete: (() -> Unit)?,
+    onDismiss: () -> Unit
+) {
+    var title by remember(initial) { mutableStateOf(initial?.title.orEmpty()) }
+    var mimeText by remember(initial) { mutableStateOf(initial?.mimeTypes?.sorted()?.joinToString("\n").orEmpty()) }
+    var extensionText by remember(initial) { mutableStateOf(initial?.extensions?.sorted()?.joinToString("\n").orEmpty()) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    fun parseSet(text: String): Set<String> = text
+        .split(',', ';', '\n', '\r', '\t', ' ')
+        .map(String::trim)
+        .filter(String::isNotEmpty)
+        .toSet()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(if (initial == null) "添加 ${preset.title}" else "编辑 ${initial.title}") },
+        text = {
+            Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(title, { title = it; error = null }, label = { Text("名称") }, singleLine = true, modifier = Modifier.fillMaxWidth())
+                OutlinedTextField(
+                    mimeText, { mimeText = it; error = null },
+                    label = { Text("MIME（每行或逗号分隔）") },
+                    supportingText = { Text("例如 application/vnd.amazon.ebook 或 application/*") },
+                    modifier = Modifier.fillMaxWidth().heightIn(min = 96.dp)
+                )
+                OutlinedTextField(
+                    extensionText, { extensionText = it; error = null },
+                    label = { Text("文件后缀（每行或逗号分隔）") },
+                    supportingText = { Text("例如 azw3, mobi, m3u8；可写或不写开头的点") },
+                    modifier = Modifier.fillMaxWidth().heightIn(min = 96.dp)
+                )
+                error?.let { Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall) }
+            }
+        },
+        confirmButton = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                onDelete?.let { delete -> TextButton(onClick = delete) { Text("删除", color = MaterialTheme.colorScheme.error) } }
+                TextButton(onClick = {
+                    runCatching {
+                        CustomOpenDefinition(title, parseSet(mimeText), parseSet(extensionText)).validated()
+                    }.onSuccess(onSave).onFailure { error = it.message ?: "配置无效" }
+                }) { Text("保存") }
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
+}

--- a/app/src/main/java/com/yagay/ListCleaner/ui/DiagnosticCollector.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/DiagnosticCollector.kt
@@ -2,6 +2,7 @@ package com.yagay.ListCleaner.ui
 
 import android.content.Context
 import android.os.Build
+import android.os.SystemClock
 import com.yagay.ListCleaner.BuildConfig
 import com.yagay.ListCleaner.ListCleanerApp
 import kotlinx.coroutines.Dispatchers
@@ -12,7 +13,6 @@ import java.io.FileOutputStream
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.ZoneId
-import android.os.SystemClock
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import java.util.zip.ZipEntry
@@ -61,7 +61,6 @@ object DiagnosticCollector {
                 }
                 zip.addText("app/scan-candidates.txt", "truncated=${candidateEvidence.truncated()}\n" +
                     candidateEvidence.snapshot().toString(StandardCharsets.UTF_8))
-                // Capture volatile buffers first, before slower file and package inspection.
                 zip.addCapture("logcat/buffer-state.txt", root("logcat -g -b all", 128 * 1024))
                 zip.addCapture("root/root-status.txt", root("id; getenforce; command -v su; echo KERNEL=$(uname -a)"))
                 zip.addCapture("logcat/ListCleaner.txt", root(
@@ -102,7 +101,6 @@ object DiagnosticCollector {
             maxBytes = 512 * 1024
         )
         zip.addCapture("lsposed/listing.txt", listing)
-        // Preserve valid paths even when find reports a partial failure.
         listing.bytes.toString(StandardCharsets.UTF_8).lineSequence()
             .mapNotNull { line ->
                 val fields = line.split(' ', limit = 2)
@@ -118,10 +116,7 @@ object DiagnosticCollector {
                 val source = "lsposed/${index.toString().padStart(2, '0')}-$safeName"
                 val capture = root("cat -- '${path.replace("'", "'\\''")}'", MAX_LSPOSED_FILE_BYTES)
                 zip.addCapture(source, capture)
-                capture.bytes.toString(StandardCharsets.UTF_8).lineSequence()
-                    .forEach { line ->
-                        evidence.accept(source, line)
-                    }
+                capture.bytes.toString(StandardCharsets.UTF_8).lineSequence().forEach { line -> evidence.accept(source, line) }
             }
         zip.addText("analysis/module-evidence.txt", evidence.report())
     }
@@ -136,7 +131,6 @@ object DiagnosticCollector {
         appendLine("grantedScope=${state.module.grantedScope.sorted().joinToString()}")
         appendLine("missingScope=${state.module.missingScope.sorted().joinToString()}")
         appendLine("displayMode=${state.displayMode.name}")
-        appendLine("legacyTileRulesIgnored=true enabled=${state.tiles.enabled} hiddenTiles=${state.tiles.hidden.size}")
         appendLine("diagnosticMode=${state.diagnosticMode}")
         appendLine("syncStatus=${state.syncStatus}")
         appendLine("systemConfigAcknowledged=${state.runtime.ready}")
@@ -144,13 +138,14 @@ object DiagnosticCollector {
         appendLine("runtimeObservedAtMillis=${state.runtime.observedAtMillis}")
         appendLine("runtimeObservationAgeMillis=${System.currentTimeMillis() - state.runtime.observedAtMillis}")
         appendLine("configDigest=${state.runtime.digest}")
+        appendLine("queryHits=${state.runtime.queryHits}")
+        appendLine("visibilityHits=${state.runtime.visibilityHits}")
+        appendLine("orderingHits=${state.runtime.orderingHits}")
         appendLine("recoveryDecisionRequired=${state.runtime.needsDecision}")
         appendLine("runtimeMessage=${state.runtime.message}")
         appendLine("uiFilter=${state.uiFilter} category=${state.filter}")
         appendLine("searchActive=${state.query.isNotBlank()} candidates=${state.candidates.size} visibleGroups=${state.groups.size}")
-        state.module.runningTargets.forEach {
-            appendLine("target=${it.processName}|${it.state}|version=${it.version}")
-        }
+        state.module.runningTargets.forEach { appendLine("target=${it.processName}|${it.state}|version=${it.version}") }
         state.module.detection.hosts.forEach {
             appendLine("host=${it.packageName}|${it.className}|${it.processName}|${it.scenarios.sorted().joinToString()}")
         }
@@ -165,8 +160,18 @@ object DiagnosticCollector {
         state.priorities.apps.entries.sortedBy { it.key.ordinal }.forEach { (kind, packages) ->
             appendLine("${kind.name}=${packages.joinToString()}")
         }
-        appendLine("tilesEnabled=${state.tiles.enabled}")
-        state.tiles.hidden.sorted().forEach { appendLine("hiddenTile=$it") }
+        appendLine("openTypeRules:")
+        state.openTypesExplicit.rules.entries.sortedBy { it.key.ordinal }.forEach { (preset, ids) ->
+            appendLine("${preset.name}=${ids.sorted().joinToString()}")
+        }
+        appendLine("openTypePriorities:")
+        state.openTypesExplicit.priorities.entries.sortedBy { it.key.ordinal }.forEach { (preset, packages) ->
+            appendLine("${preset.name}=${packages.joinToString()}")
+        }
+        appendLine("customOpenTypes:")
+        state.openTypesExplicit.customDefinitions.entries.sortedBy { it.key.ordinal }.forEach { (preset, definition) ->
+            appendLine("${preset.name}|name=${definition.name}|mimes=${definition.mimeTypes.sorted().joinToString()}|extensions=${definition.extensions.sorted().joinToString()}")
+        }
     }
 
     private fun systemInfo(): String = buildString {
@@ -191,13 +196,14 @@ object DiagnosticCollector {
         Generated read-only. No command changes system state.
 
         Contents:
-        - app/: module state, LSPosed scope, running targets and active rules
+        - app/: module state, LSPosed scope, running targets, active rules and typed OPEN configuration
         - device/: Android/build information
         - logcat/: module/framework/resolver logs, activity events, crash and buffer state
         - lsposed/: newest 12 log files modified within 24 hours, each retaining up to 4 MiB
         - root/: root status and installed module metadata
 
         Logcat and LSPosed logs may contain package names, paths or user activity. Review before sharing.
+        Runtime ListCleaner messages log file extensions and recognized types, not full file names or URIs.
         Large streams retain their beginning and latest end, with an explicit omitted-byte marker.
         Storage is bounded per entry (8 MiB normally). Startup logs already overwritten cannot be recovered.
         The module also writes lifecycle and rate-limited diagnostic messages to the framework log
@@ -215,9 +221,7 @@ object DiagnosticCollector {
         val readFailure = AtomicReference<String?>(null)
         var process: Process? = null
         return try {
-            val running = ProcessBuilder(command)
-                .redirectErrorStream(true)
-                .start()
+            val running = ProcessBuilder(command).redirectErrorStream(true).start()
             process = running
             val reader = Thread({
                 try {
@@ -245,7 +249,7 @@ object DiagnosticCollector {
         } catch (interrupted: InterruptedException) {
             throw interrupted
         } catch (failure: Exception) {
-            Capture((failure.stackTraceToString()).toByteArray(), -1, false, false,
+            Capture(failure.stackTraceToString().toByteArray(), -1, false, false,
                 startedAt, Instant.now().toString(), buffer.totalBytes(), true)
         } finally {
             runCatching { process?.destroyForcibly() }

--- a/app/src/main/java/com/yagay/ListCleaner/ui/DiagnosticCollector.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/DiagnosticCollector.kt
@@ -170,7 +170,7 @@ object DiagnosticCollector {
         }
         appendLine("customOpenTypes:")
         state.openTypesExplicit.customDefinitions.entries.sortedBy { it.key.ordinal }.forEach { (preset, definition) ->
-            appendLine("${preset.name}|name=${definition.name}|mimes=${definition.mimeTypes.sorted().joinToString()}|extensions=${definition.extensions.sorted().joinToString()}")
+            appendLine("${preset.name}|title=${definition.title}|mimes=${definition.mimeTypes.sorted().joinToString()}|extensions=${definition.extensions.sorted().joinToString()}")
         }
     }
 

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainTabs.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainTabs.kt
@@ -12,12 +12,15 @@ import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.yagay.ListCleaner.domain.DisplayMode
 import com.yagay.ListCleaner.domain.IntentKind
+import com.yagay.ListCleaner.domain.OpenPreset
+import com.yagay.ListCleaner.domain.matchesOpenPreset
 import com.yagay.ListCleaner.BuildConfig
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -29,7 +32,15 @@ fun RulesTab(state: MainState, vm: MainViewModel) {
             onSave = { vm.setComponentTitle(item.rule.id, it) },
             onDismiss = { editingTitle = null })
     }
-    val visibleRules = state.groups.flatMap { it.components }.map { it.rule }.distinct()
+    var openPreset by rememberSaveable { mutableStateOf<OpenPreset?>(null) }
+    LaunchedEffect(state.filter) { if (state.filter != IntentKind.OPEN) openPreset = null }
+    val typedSelected = openPreset?.let { state.openTypes.selectedRules(it) }.orEmpty()
+    val shownGroups = if (state.filter == IntentKind.OPEN && openPreset != null) {
+        groupCandidates(state.candidates.filter { it.matchesOpenPreset(openPreset!!) }, typedSelected,
+            IntentKind.OPEN, state.query, state.uiFilter)
+    } else state.groups
+    val activeSelected = if (openPreset != null && state.filter == IntentKind.OPEN) typedSelected else state.selected
+    val visibleRules = shownGroups.flatMap { it.components }.map { it.rule }.distinct()
 
     LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = 16.dp)) {
         item(key = "module-indicator") {
@@ -38,14 +49,17 @@ fun RulesTab(state: MainState, vm: MainViewModel) {
         }
         stickyHeader(key = "list-controls") {
             Surface(tonalElevation = 2.dp) {
-                ListControls(state, vm::setFilter, vm::setUiFilter,
-                    onSelectAll = { vm.selectRules(visibleRules) },
-                    onInvert = { vm.invertRules(visibleRules) })
+                Column {
+                    ListControls(state, vm::setFilter, vm::setUiFilter,
+                        onSelectAll = { if (openPreset != null && state.filter == IntentKind.OPEN) vm.selectOpenTypeRules(openPreset!!, visibleRules) else vm.selectRules(visibleRules) },
+                        onInvert = { if (openPreset != null && state.filter == IntentKind.OPEN) vm.invertOpenTypeRules(openPreset!!, visibleRules) else vm.invertRules(visibleRules) })
+                    if (state.filter == IntentKind.OPEN) OpenPresetFilterRow(openPreset, { openPreset = it })
+                }
             }
         }
         item(key = "list-summary") {
-            SummaryRow(state)
-            if (state.uiFilter != UiFilter.SHOW_SELECTED && state.candidates.any {
+            SummaryRow(state, shownGroups.size, openPreset)
+            if (openPreset == null && state.uiFilter != UiFilter.SHOW_SELECTED && state.candidates.any {
                     it.rule in state.selected && (it.unavailable || it.restricted)
                 }) {
                 TextButton(onClick = {
@@ -55,31 +69,32 @@ fun RulesTab(state: MainState, vm: MainViewModel) {
                 }, modifier = Modifier.padding(horizontal = 16.dp)) { Text("查看未匹配的已选规则") }
             }
         }
-        state.groups.forEach { group ->
-            val key = "${state.filter?.name ?: "ALL"}|${group.packageName}"
+        shownGroups.forEach { group ->
+            val key = "${state.filter?.name ?: "ALL"}|${openPreset?.name ?: "ALL"}|${group.packageName}"
             val expanded = state.expandedAppKey == key
             item(key = "app|${group.packageName}", contentType = "app") {
-                AppRow(group, state.selected, expanded,
+                AppRow(group, activeSelected, expanded,
                     { vm.toggleExpandedApp(key) },
-                    { selected -> vm.setGroupSelected(group, selected) })
+                    { selected -> if (openPreset != null && state.filter == IntentKind.OPEN) vm.setOpenTypeGroupSelected(openPreset!!, group, selected) else vm.setGroupSelected(group, selected) })
             }
             if (expanded) {
                 items(group.components, key = { "component|${it.rule.id}" }, contentType = { "component" }) { component ->
-                    ComponentRow(component, component.rule in state.selected, state.priorities.titles[component.rule.id],
-                        onToggle = { vm.toggle(component.rule) }, onEditTitle = { editingTitle = component })
+                    ComponentRow(component, component.rule in activeSelected, state.priorities.titles[component.rule.id],
+                        onToggle = { if (openPreset != null && state.filter == IntentKind.OPEN) vm.toggleOpenType(openPreset!!, component.rule) else vm.toggle(component.rule) },
+                        onEditTitle = { editingTitle = component })
                 }
             }
         }
-        if (!state.loading && state.groups.isEmpty()) {
+        if (!state.loading && shownGroups.isEmpty()) {
             item { Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) { Text("没有匹配的组件") } }
         }
     }
 }
 
 @Composable
-private fun SummaryRow(state: MainState) {
+private fun SummaryRow(state: MainState, groupCount: Int = state.groups.size, openPreset: OpenPreset? = null) {
     Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-        Text("应用列表 · ${state.groups.size}", style = MaterialTheme.typography.labelLarge)
+        Text("应用列表 · $groupCount" + (openPreset?.let { " · ${it.title}" } ?: ""), style = MaterialTheme.typography.labelLarge)
         Text("本页用于管理分享、多文件分享、打开方式、浏览器和文本处理等 Intent 候选入口：可按规则隐藏/保留组件，也可单独修改组件在系统候选菜单中的显示名称；不会修改实际 Intent、包名、组件名，也不会停用或卸载应用。",
             style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Text(when (state.displayMode) {
@@ -87,7 +102,7 @@ private fun SummaryRow(state: MainState) {
             DisplayMode.SHOW_SELECTED -> "当前为“只显示选中”：规则生效后，对应分类保留勾选的组件，隐藏其他组件。"
             DisplayMode.SHOW_ALL -> "当前为“全部显示”：暂停清理系统候选列表，勾选只保存配置，恢复清理模式后生效。"
         }, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text("勾选应用可批量选择当前分类及搜索条件下显示的组件；展开后可逐项选择，点铅笔可设置该组件在当前分类中的菜单显示名称。改名与是否勾选规则相互独立；留空保存恢复原名称。“查看”只筛选本页列表，不改变清理规则。",
+        Text(if (openPreset == null) "勾选应用可批量选择当前分类及搜索条件下显示的组件；展开后可逐项选择，点铅笔可设置该组件在当前分类中的菜单显示名称。改名与是否勾选规则相互独立；留空保存恢复原名称。“查看”只筛选本页列表，不改变清理规则。" else "当前正在编辑“打开方式 · ${openPreset.title}”专用规则，只影响匹配该 MIME / scheme 类型的打开菜单；“全部”中的 OPEN 通用规则仍会同时生效。",
             style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         if (state.displayMode == DisplayMode.SHOW_ALL) {
             Text(if (state.runtime.ready) "system 已确认暂停过滤、排序和自定义显示名称；相关配置仍保留" else "本地已选择暂停，尚未确认系统已应用", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainTabs.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainTabs.kt
@@ -102,7 +102,7 @@ private fun SummaryRow(state: MainState, groupCount: Int = state.groups.size, op
             DisplayMode.SHOW_SELECTED -> "当前为“只显示选中”：规则生效后，对应分类保留勾选的组件，隐藏其他组件。"
             DisplayMode.SHOW_ALL -> "当前为“全部显示”：暂停清理系统候选列表，勾选只保存配置，恢复清理模式后生效。"
         }, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(if (openPreset == null) "勾选应用可批量选择当前分类及搜索条件下显示的组件；展开后可逐项选择，点铅笔可设置该组件在当前分类中的菜单显示名称。改名与是否勾选规则相互独立；留空保存恢复原名称。“查看”只筛选本页列表，不改变清理规则。" else "当前正在编辑“打开方式 · ${openPreset.title}”专用规则，只影响匹配该 MIME / scheme 类型的打开菜单；“全部”中的 OPEN 通用规则仍会同时生效。",
+        Text(if (openPreset == null) "勾选应用可批量选择当前分类及搜索条件下显示的组件；展开后可逐项选择，点铅笔可设置该组件在当前分类中的菜单显示名称。改名与是否勾选规则相互独立；留空保存恢复原名称。“查看”只筛选本页列表，不改变清理规则。" else "当前正在编辑“打开方式 · ${openPreset.title}”专用规则。该页面的有效勾选 = “全部”中的 OPEN 通用规则 + 当前类型专用规则，因此从“全部”继承的项目也会显示为已勾选并继续生效；继承项不能在当前分类型里单独取消，需要回到“全部”取消。当前类型新增的专用规则只影响匹配该 MIME / scheme 类型的打开菜单。",
             style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         if (state.displayMode == DisplayMode.SHOW_ALL) {
             Text(if (state.runtime.ready) "system 已确认暂停过滤、排序和自定义显示名称；相关配置仍保留" else "本地已选择暂停，尚未确认系统已应用", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainTabs.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainTabs.kt
@@ -27,18 +27,31 @@ import com.yagay.ListCleaner.BuildConfig
 @Composable
 fun RulesTab(state: MainState, vm: MainViewModel) {
     var editingTitle by remember { mutableStateOf<com.yagay.ListCleaner.domain.ComponentCandidate?>(null) }
+    var showCustomTypes by rememberSaveable { mutableStateOf(false) }
     editingTitle?.let { item ->
         ComponentTitleDialog(item, state.priorities.titles[item.rule.id],
             onSave = { vm.setComponentTitle(item.rule.id, it) },
             onDismiss = { editingTitle = null })
     }
+    if (showCustomTypes) {
+        CustomOpenTypeDialog(
+            config = state.openTypesExplicit,
+            onSave = vm::setCustomOpenDefinition,
+            onDismiss = { showCustomTypes = false }
+        )
+    }
     var openPreset by rememberSaveable { mutableStateOf<OpenPreset?>(null) }
     LaunchedEffect(state.filter) { if (state.filter != IntentKind.OPEN) openPreset = null }
+    LaunchedEffect(state.openTypesExplicit.customDefinitions, openPreset) {
+        if (openPreset?.isCustom == true && openPreset !in state.openTypesExplicit.customDefinitions) openPreset = null
+    }
     val typedSelected = openPreset?.let { state.openTypes.selectedRules(it) }.orEmpty()
     val explicitTypedSelected = openPreset?.let { state.openTypesExplicit.selectedRules(it) }.orEmpty()
     val shownGroups = if (state.filter == IntentKind.OPEN && openPreset != null) {
-        groupCandidates(state.candidates.filter { it.matchesOpenPreset(openPreset!!) }, typedSelected,
-            IntentKind.OPEN, state.query, state.uiFilter)
+        groupCandidates(
+            state.candidates.filter { it.matchesOpenPreset(openPreset!!, state.openTypesExplicit.customDefinitions) },
+            typedSelected, IntentKind.OPEN, state.query, state.uiFilter
+        )
     } else state.groups
     val activeSelected = if (openPreset != null && state.filter == IntentKind.OPEN) typedSelected else state.selected
     val visibleRules = shownGroups.flatMap { it.components }.map { it.rule }.distinct()
@@ -54,7 +67,14 @@ fun RulesTab(state: MainState, vm: MainViewModel) {
                     ListControls(state, vm::setFilter, vm::setUiFilter,
                         onSelectAll = { if (openPreset != null && state.filter == IntentKind.OPEN) vm.selectOpenTypeRules(openPreset!!, visibleRules) else vm.selectRules(visibleRules) },
                         onInvert = { if (openPreset != null && state.filter == IntentKind.OPEN) vm.invertOpenTypeRules(openPreset!!, visibleRules) else vm.invertRules(visibleRules) })
-                    if (state.filter == IntentKind.OPEN) OpenPresetFilterRow(openPreset, { openPreset = it })
+                    if (state.filter == IntentKind.OPEN) {
+                        OpenPresetFilterRow(
+                            selected = openPreset,
+                            config = state.openTypesExplicit,
+                            onSelected = { openPreset = it },
+                            onManageCustom = { showCustomTypes = true }
+                        )
+                    }
                 }
             }
         }
@@ -83,7 +103,7 @@ fun RulesTab(state: MainState, vm: MainViewModel) {
                     val sourceNote = if (openPreset != null && state.filter == IntentKind.OPEN && component.rule in activeSelected) {
                         when {
                             component.rule in state.selected -> "继承自“打开方式 · 全部”"
-                            component.rule in explicitTypedSelected -> "${openPreset!!.title} 专用规则"
+                            component.rule in explicitTypedSelected -> "${state.openTypes.titleFor(openPreset!!)} 专用规则"
                             else -> null
                         }
                     } else null
@@ -102,8 +122,9 @@ fun RulesTab(state: MainState, vm: MainViewModel) {
 
 @Composable
 private fun SummaryRow(state: MainState, groupCount: Int = state.groups.size, openPreset: OpenPreset? = null) {
+    val presetTitle = openPreset?.let(state.openTypes::titleFor)
     Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-        Text("应用列表 · $groupCount" + (openPreset?.let { " · ${it.title}" } ?: ""), style = MaterialTheme.typography.labelLarge)
+        Text("应用列表 · $groupCount" + (presetTitle?.let { " · $it" } ?: ""), style = MaterialTheme.typography.labelLarge)
         Text("本页用于管理分享、多文件分享、打开方式、浏览器和文本处理等 Intent 候选入口：可按规则隐藏/保留组件，也可单独修改组件在系统候选菜单中的显示名称；不会修改实际 Intent、包名、组件名，也不会停用或卸载应用。",
             style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         Text(when (state.displayMode) {
@@ -111,7 +132,7 @@ private fun SummaryRow(state: MainState, groupCount: Int = state.groups.size, op
             DisplayMode.SHOW_SELECTED -> "当前为“只显示选中”：规则生效后，对应分类保留勾选的组件，隐藏其他组件。"
             DisplayMode.SHOW_ALL -> "当前为“全部显示”：暂停清理系统候选列表，勾选只保存配置，恢复清理模式后生效。"
         }, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(if (openPreset == null) "勾选应用可批量选择当前分类及搜索条件下显示的组件；展开后可逐项选择，点铅笔可设置该组件在当前分类中的菜单显示名称。改名与是否勾选规则相互独立；留空保存恢复原名称。“查看”只筛选本页列表，不改变清理规则。" else "当前正在编辑“打开方式 · ${openPreset.title}”专用规则。有效勾选由“全部”中的 OPEN 通用规则与当前类型专用规则共同组成；继承自“全部”的项目会继续显示已勾选，并在展开项中标明来源。继承项不能在分类型里直接取消，需要回到“全部”取消；当前类型新增的规则只影响该 MIME / scheme 类型。",
+        Text(if (openPreset == null) "勾选应用可批量选择当前分类及搜索条件下显示的组件；展开后可逐项选择，点铅笔可设置该组件在当前分类中的菜单显示名称。改名与是否勾选规则相互独立；留空保存恢复原名称。“查看”只筛选本页列表，不改变清理规则。" else "当前正在编辑“打开方式 · $presetTitle”专用规则。有效勾选由“全部”中的 OPEN 通用规则与当前类型专用规则共同组成；继承自“全部”的项目会继续显示已勾选，并在展开项中标明来源。继承项不能在分类型里直接取消，需要回到“全部”取消；当前类型新增的规则只影响该 MIME / scheme / 文件后缀类型。",
             style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         if (state.displayMode == DisplayMode.SHOW_ALL) {
             Text(if (state.runtime.ready) "system 已确认暂停过滤、排序和自定义显示名称；相关配置仍保留" else "本地已选择暂停，尚未确认系统已应用", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
@@ -143,10 +164,7 @@ fun DashboardTabContent(
     var showScopeDetails by remember { mutableStateOf(false) }
     var showAppScopePicker by remember { mutableStateOf(false) }
     if (showScopeDetails) ScopeDialog(state.module, vm::requestScope, vm::refreshModuleStatus) { showScopeDetails = false }
-    if (showAppScopePicker) AppScopePickerDialog(
-        selected = state.hiddenFromApps,
-        onSelectedChange = vm::setHiddenFromApps,
-    ) { showAppScopePicker = false }
+    if (showAppScopePicker) AppScopePickerDialog(selected = state.hiddenFromApps, onSelectedChange = vm::setHiddenFromApps) { showAppScopePicker = false }
     Column(Modifier.fillMaxSize().padding(16.dp).verticalScroll(rememberScrollState()), verticalArrangement = Arrangement.spacedBy(16.dp)) {
         RuntimePanel(state, vm)
         Text("全局清理模式", style = MaterialTheme.typography.titleMedium)
@@ -157,15 +175,10 @@ fun DashboardTabContent(
                     Text("控制系统选择器如何处理已选组件。", style = MaterialTheme.typography.bodySmall)
                 }
                 Box {
-                    TextButton(onClick = { menu = true }) {
-                        Text("切换")
-                        Icon(Icons.Rounded.ExpandMore, null, Modifier.size(18.dp))
-                    }
+                    TextButton(onClick = { menu = true }) { Text("切换"); Icon(Icons.Rounded.ExpandMore, null, Modifier.size(18.dp)) }
                     DropdownMenu(expanded = menu, onDismissRequest = { menu = false }) {
                         DisplayMode.entries.forEach { mode ->
-                            DropdownMenuItem(text = { Text(mode.title) },
-                                leadingIcon = { if (mode == state.displayMode) Icon(Icons.Rounded.Check, null) },
-                                onClick = { menu = false; vm.setDisplayMode(mode) })
+                            DropdownMenuItem(text = { Text(mode.title) }, leadingIcon = { if (mode == state.displayMode) Icon(Icons.Rounded.Check, null) }, onClick = { menu = false; vm.setDisplayMode(mode) })
                         }
                     }
                 }
@@ -187,8 +200,7 @@ fun DashboardTabContent(
                 Text("Intent 查询 Hook：${state.runtime.queryHits} 次", style = MaterialTheme.typography.bodySmall)
                 Text("应用可见性兼容过滤：${state.runtime.visibilityHits} 次", style = MaterialTheme.typography.bodySmall)
                 Text("system 进程记录到的排序改写：${state.runtime.orderingHits} 次", style = MaterialTheme.typography.bodySmall)
-                Text("查询和应用可见性计数来自 system_server 的真实执行。排序通常在独立 Resolver/Chooser 进程执行，因此这里的排序计数为 0 不能单独判定排序失效；诊断模式会记录 Resolver 侧 ORDER_DELIVERED，实际菜单仍以设备复现为准。",
-                    style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text("查询和应用可见性计数来自 system_server 的真实执行。排序通常在独立 Resolver/Chooser 进程执行，因此这里的排序计数为 0 不能单独判定排序失效；诊断模式会记录 Resolver 侧 ORDER_DELIVERED，实际菜单仍以设备复现为准。", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 OutlinedButton(onClick = vm::refreshModuleStatus, modifier = Modifier.fillMaxWidth()) { Text("刷新运行状态") }
             }
         }
@@ -200,20 +212,13 @@ fun DashboardTabContent(
         }
 
         Text("模块状态", style = MaterialTheme.typography.titleMedium)
-        ModuleStatusRow(state) {
-            showScopeDetails = true
-            vm.refreshModuleStatus()
-        }
+        ModuleStatusRow(state) { showScopeDetails = true; vm.refreshModuleStatus() }
         Card(Modifier.fillMaxWidth()) {
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text("应用隐藏列表", fontWeight = FontWeight.Bold)
-                Text("用于普通 Resolver 规则对某些文件管理器不起作用时的兼容方案，例如 ES 自己生成的打开方式列表。启用后，从指定来源应用可见的已安装应用列表中隐藏“打开方式”规则目标；只跟随 OPEN 通用规则和 PDF、APK、图片、视频等分类型 OPEN 规则，不会再因为分享或文本处理规则而隐藏目标包。", style = MaterialTheme.typography.bodySmall)
-                Button(
-                    onClick = { showAppScopePicker = true },
-                    modifier = Modifier.fillMaxWidth()
-                ) { Text("管理应用隐藏列表（${state.hiddenFromApps.size}）") }
-                Text("勾选立即保存；仅在“隐藏选中”模式生效。实现位于 android/system_server，属于包级隐藏：命中后该目标包会整体对来源应用不可见，无法只隐藏其中一个 Activity。",
-                    style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text("用于普通 Resolver 规则对某些文件管理器不起作用时的兼容方案，例如 ES 自己生成的打开方式列表。启用后，从指定来源应用可见的已安装应用列表中隐藏“打开方式”规则目标；只跟随 OPEN 通用规则和内置/自定义分类型 OPEN 规则，不会再因为分享或文本处理规则而隐藏目标包。", style = MaterialTheme.typography.bodySmall)
+                Button(onClick = { showAppScopePicker = true }, modifier = Modifier.fillMaxWidth()) { Text("管理应用隐藏列表（${state.hiddenFromApps.size}）") }
+                Text("勾选立即保存；仅在“隐藏选中”模式生效。实现位于 android/system_server，属于包级隐藏：命中后该目标包会整体对来源应用不可见，无法只隐藏其中一个 Activity。", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
         }
 
@@ -222,26 +227,13 @@ fun DashboardTabContent(
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 state.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
                 Text("扫描只用于发现可管理组件，不保证等同于每次实际菜单。非文本分类保留空列表保护；文本允许隐藏全部候选，不处理应用硬编码菜单。", style = MaterialTheme.typography.labelSmall)
-                OutlinedButton(onClick = onInspectFile, enabled = !checkingFile, modifier = Modifier.fillMaxWidth()) {
-                    Text(if (checkingFile) "正在检查文件…" else "用实际文件预览最终打开方式")
-                }
+                OutlinedButton(onClick = onInspectFile, enabled = !checkingFile, modifier = Modifier.fillMaxWidth()) { Text(if (checkingFile) "正在检查文件…" else "用实际文件预览最终打开方式") }
                 fileCheckStatus?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text("诊断模式", Modifier.weight(1f))
-                    Switch(state.diagnosticMode, vm::setDiagnosticMode)
-                }
-                Text("开启后记录查询分类、规则与跳过原因；按分类和调用UID记录首个有效查询栈。管理扫描不占用调用栈记录。运行时只记录文件扩展名和识别类型，不记录完整文件名或 URI。每进程每5秒关键记录最多200条，候选明细另限40条。",
-                     style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Row(verticalAlignment = Alignment.CenterVertically) { Text("诊断模式", Modifier.weight(1f)); Switch(state.diagnosticMode, vm::setDiagnosticMode) }
+                Text("开启后记录查询分类、规则与跳过原因；按分类和调用UID记录首个有效查询栈。管理扫描不占用调用栈记录。运行时只记录文件扩展名和识别类型，不记录完整文件名或 URI。每进程每5秒关键记录最多200条，候选明细另限40条。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 if (state.diagnosticMode) Text("诊断已开启；请复现分享、打开或文本处理操作。", style = MaterialTheme.typography.bodySmall)
-                Button(
-                    onClick = onCollectDiagnostics,
-                    enabled = !collectingDiagnostics,
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    if (collectingDiagnostics) {
-                        CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
-                        Spacer(Modifier.width(8.dp))
-                    }
+                Button(onClick = onCollectDiagnostics, enabled = !collectingDiagnostics, modifier = Modifier.fillMaxWidth()) {
+                    if (collectingDiagnostics) { CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp); Spacer(Modifier.width(8.dp)) }
                     Text(if (collectingDiagnostics) "正在收集" else "一键导出诊断包")
                 }
                 Text("先开启诊断，再复现问题，最后导出。包含最近24小时内最多12份 LSPosed 日志；大文件保留开头与最新结尾。系统原始日志仍可能包含其他进程隐私，分享前请检查。需要 Root 授权，读取失败会记录在包内。", style = MaterialTheme.typography.labelSmall)
@@ -249,7 +241,6 @@ fun DashboardTabContent(
         }
 
         Spacer(Modifier.height(32.dp))
-        Text("${androidx.compose.ui.res.stringResource(com.yagay.ListCleaner.R.string.app_name)} v${BuildConfig.VERSION_NAME}", modifier = Modifier.align(Alignment.CenterHorizontally),
-             style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text("${androidx.compose.ui.res.stringResource(com.yagay.ListCleaner.R.string.app_name)} v${BuildConfig.VERSION_NAME}", modifier = Modifier.align(Alignment.CenterHorizontally), style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
     }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainTabs.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainTabs.kt
@@ -35,6 +35,7 @@ fun RulesTab(state: MainState, vm: MainViewModel) {
     var openPreset by rememberSaveable { mutableStateOf<OpenPreset?>(null) }
     LaunchedEffect(state.filter) { if (state.filter != IntentKind.OPEN) openPreset = null }
     val typedSelected = openPreset?.let { state.openTypes.selectedRules(it) }.orEmpty()
+    val explicitTypedSelected = openPreset?.let { state.openTypesExplicit.selectedRules(it) }.orEmpty()
     val shownGroups = if (state.filter == IntentKind.OPEN && openPreset != null) {
         groupCandidates(state.candidates.filter { it.matchesOpenPreset(openPreset!!) }, typedSelected,
             IntentKind.OPEN, state.query, state.uiFilter)
@@ -79,7 +80,15 @@ fun RulesTab(state: MainState, vm: MainViewModel) {
             }
             if (expanded) {
                 items(group.components, key = { "component|${it.rule.id}" }, contentType = { "component" }) { component ->
+                    val sourceNote = if (openPreset != null && state.filter == IntentKind.OPEN && component.rule in activeSelected) {
+                        when {
+                            component.rule in state.selected -> "继承自“打开方式 · 全部”"
+                            component.rule in explicitTypedSelected -> "${openPreset!!.title} 专用规则"
+                            else -> null
+                        }
+                    } else null
                     ComponentRow(component, component.rule in activeSelected, state.priorities.titles[component.rule.id],
+                        selectionNote = sourceNote,
                         onToggle = { if (openPreset != null && state.filter == IntentKind.OPEN) vm.toggleOpenType(openPreset!!, component.rule) else vm.toggle(component.rule) },
                         onEditTitle = { editingTitle = component })
                 }
@@ -102,7 +111,7 @@ private fun SummaryRow(state: MainState, groupCount: Int = state.groups.size, op
             DisplayMode.SHOW_SELECTED -> "当前为“只显示选中”：规则生效后，对应分类保留勾选的组件，隐藏其他组件。"
             DisplayMode.SHOW_ALL -> "当前为“全部显示”：暂停清理系统候选列表，勾选只保存配置，恢复清理模式后生效。"
         }, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(if (openPreset == null) "勾选应用可批量选择当前分类及搜索条件下显示的组件；展开后可逐项选择，点铅笔可设置该组件在当前分类中的菜单显示名称。改名与是否勾选规则相互独立；留空保存恢复原名称。“查看”只筛选本页列表，不改变清理规则。" else "当前正在编辑“打开方式 · ${openPreset.title}”专用规则。该页面的有效勾选 = “全部”中的 OPEN 通用规则 + 当前类型专用规则，因此从“全部”继承的项目也会显示为已勾选并继续生效；继承项不能在当前分类型里单独取消，需要回到“全部”取消。当前类型新增的专用规则只影响匹配该 MIME / scheme 类型的打开菜单。",
+        Text(if (openPreset == null) "勾选应用可批量选择当前分类及搜索条件下显示的组件；展开后可逐项选择，点铅笔可设置该组件在当前分类中的菜单显示名称。改名与是否勾选规则相互独立；留空保存恢复原名称。“查看”只筛选本页列表，不改变清理规则。" else "当前正在编辑“打开方式 · ${openPreset.title}”专用规则。有效勾选由“全部”中的 OPEN 通用规则与当前类型专用规则共同组成；继承自“全部”的项目会继续显示已勾选，并在展开项中标明来源。继承项不能在分类型里直接取消，需要回到“全部”取消；当前类型新增的规则只影响该 MIME / scheme 类型。",
             style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         if (state.displayMode == DisplayMode.SHOW_ALL) {
             Text(if (state.runtime.ready) "system 已确认暂停过滤、排序和自定义显示名称；相关配置仍保留" else "本地已选择暂停，尚未确认系统已应用", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.primary)
@@ -170,7 +179,20 @@ fun DashboardTabContent(
                 Text("本地保存不等于系统生效；以配置确认状态为准，Resolver 侧效果仍需实际验证。", style = MaterialTheme.typography.bodySmall)
             }
         }
-        
+
+        Text("运行能力与实际命中", style = MaterialTheme.typography.titleMedium)
+        Card(Modifier.fillMaxWidth()) {
+            Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                Text(if (state.runtime.ready) "system_server 已确认当前配置" else "尚未取得当前配置 ACK", fontWeight = FontWeight.Bold)
+                Text("Intent 查询 Hook：${state.runtime.queryHits} 次", style = MaterialTheme.typography.bodySmall)
+                Text("应用可见性兼容过滤：${state.runtime.visibilityHits} 次", style = MaterialTheme.typography.bodySmall)
+                Text("system 进程记录到的排序改写：${state.runtime.orderingHits} 次", style = MaterialTheme.typography.bodySmall)
+                Text("查询和应用可见性计数来自 system_server 的真实执行。排序通常在独立 Resolver/Chooser 进程执行，因此这里的排序计数为 0 不能单独判定排序失效；诊断模式会记录 Resolver 侧 ORDER_DELIVERED，实际菜单仍以设备复现为准。",
+                    style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                OutlinedButton(onClick = vm::refreshModuleStatus, modifier = Modifier.fillMaxWidth()) { Text("刷新运行状态") }
+            }
+        }
+
         Text("数据备份", style = MaterialTheme.typography.titleMedium)
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Button(onClick = onRestore, modifier = Modifier.weight(1f)) { Text("从 JSON 恢复") }
@@ -185,12 +207,13 @@ fun DashboardTabContent(
         Card(Modifier.fillMaxWidth()) {
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text("应用隐藏列表", fontWeight = FontWeight.Bold)
-                Text("用于普通规则隐藏在某些应用中不起作用时的兼容方案，例如文件管理器自己的打开方式列表。启用后，会从指定应用可见的“已安装应用列表”中隐藏规则目标，使这些应用无法查询到对应目标包；不会 Hook 这些应用，也不需要把它们加入 LSPosed 作用域。", style = MaterialTheme.typography.bodySmall)
+                Text("用于普通 Resolver 规则对某些文件管理器不起作用时的兼容方案，例如 ES 自己生成的打开方式列表。启用后，从指定来源应用可见的已安装应用列表中隐藏“打开方式”规则目标；只跟随 OPEN 通用规则和 PDF、APK、图片、视频等分类型 OPEN 规则，不会再因为分享或文本处理规则而隐藏目标包。", style = MaterialTheme.typography.bodySmall)
                 Button(
                     onClick = { showAppScopePicker = true },
                     modifier = Modifier.fillMaxWidth()
                 ) { Text("管理应用隐藏列表（${state.hiddenFromApps.size}）") }
-                Text("勾选立即保存；仅在“隐藏选中”模式生效。该功能通过 android/system_server 的系统级应用可见性过滤实现，属于包级隐藏，不区分同一应用内的单个 Activity 或组件。", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                Text("勾选立即保存；仅在“隐藏选中”模式生效。实现位于 android/system_server，属于包级隐藏：命中后该目标包会整体对来源应用不可见，无法只隐藏其中一个 Activity。",
+                    style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
         }
 
@@ -199,15 +222,15 @@ fun DashboardTabContent(
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 state.error?.let { Text(it, color = MaterialTheme.colorScheme.error) }
                 Text("扫描只用于发现可管理组件，不保证等同于每次实际菜单。非文本分类保留空列表保护；文本允许隐藏全部候选，不处理应用硬编码菜单。", style = MaterialTheme.typography.labelSmall)
-                OutlinedButton(onClick = onInspectFile, enabled = !checkingFile) {
-                    Text(if (checkingFile) "正在检查文件…" else "用实际文件检查打开方式")
+                OutlinedButton(onClick = onInspectFile, enabled = !checkingFile, modifier = Modifier.fillMaxWidth()) {
+                    Text(if (checkingFile) "正在检查文件…" else "用实际文件预览最终打开方式")
                 }
                 fileCheckStatus?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text("诊断模式", Modifier.weight(1f))
                     Switch(state.diagnosticMode, vm::setDiagnosticMode)
                 }
-                Text("开启后记录查询分类、规则与跳过原因；按分类和调用UID记录首个有效查询栈。管理扫描不占用调用栈记录。每进程每5秒关键记录最多200条，候选明细另限40条，不记录正文和完整URI。",
+                Text("开启后记录查询分类、规则与跳过原因；按分类和调用UID记录首个有效查询栈。管理扫描不占用调用栈记录。运行时只记录文件扩展名和识别类型，不记录完整文件名或 URI。每进程每5秒关键记录最多200条，候选明细另限40条。",
                      style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 if (state.diagnosticMode) Text("诊断已开启；请复现分享、打开或文本处理操作。", style = MaterialTheme.typography.bodySmall)
                 Button(
@@ -221,10 +244,10 @@ fun DashboardTabContent(
                     }
                     Text(if (collectingDiagnostics) "正在收集" else "一键导出诊断包")
                 }
-                Text("先开启诊断，再复现问题，最后导出。包含最近24小时内最多12份 LSPosed 日志；大文件保留开头与最新结尾。系统原始日志可能包含隐私，分享前请检查。需要 Root 授权，读取失败会记录在包内。", style = MaterialTheme.typography.labelSmall)
+                Text("先开启诊断，再复现问题，最后导出。包含最近24小时内最多12份 LSPosed 日志；大文件保留开头与最新结尾。系统原始日志仍可能包含其他进程隐私，分享前请检查。需要 Root 授权，读取失败会记录在包内。", style = MaterialTheme.typography.labelSmall)
             }
         }
-        
+
         Spacer(Modifier.height(32.dp))
         Text("${androidx.compose.ui.res.stringResource(com.yagay.ListCleaner.R.string.app_name)} v${BuildConfig.VERSION_NAME}", modifier = Modifier.align(Alignment.CenterHorizontally),
              style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
@@ -33,6 +33,7 @@ import com.yagay.ListCleaner.domain.PriorityConfig
 import com.yagay.ListCleaner.domain.DefaultOpenConfig
 import com.yagay.ListCleaner.domain.OpenPreset
 import com.yagay.ListCleaner.domain.OpenTypeConfig
+import com.yagay.ListCleaner.domain.CustomOpenDefinition
 import io.github.libxposed.service.XposedService
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -98,9 +99,7 @@ data class MainState(
     val diagnosticMode: Boolean = false,
     val priorities: PriorityConfig = PriorityConfig(),
     val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
-    /** Effective OPEN config shown by UI after generic inheritance is applied. */
     val openTypes: OpenTypeConfig = OpenTypeConfig(),
-    /** Raw per-type config, used to distinguish inherited values from explicit overrides. */
     val openTypesExplicit: OpenTypeConfig = OpenTypeConfig(),
     val tiles: TileConfig = TileConfig(),
     val hiddenFromApps: Set<String> = emptySet(),
@@ -126,14 +125,11 @@ fun groupCandidates(candidates: List<ComponentCandidate>, selected: Set<Componen
                 UiFilter.HIDE_SELECTED -> !isSelected
                 UiFilter.SHOW_SELECTED -> isSelected
             }
-            catalogVisible(it, isSelected, uiFilter) && matchesUiFilter && (filter == null || it.rule.kind == filter) &&
-                it.matchesQuery(query)
+            catalogVisible(it, isSelected, uiFilter) && matchesUiFilter && (filter == null || it.rule.kind == filter) && it.matchesQuery(query)
         }.sortedBy { it.rule.kind.ordinal }
-        if (matching.isEmpty()) null else AppGroup(all.first().rule.packageName, all.first().appLabel, all.first().appIcon,
-            matching)
+        if (matching.isEmpty()) null else AppGroup(all.first().rule.packageName, all.first().appLabel, all.first().appIcon, matching)
     }.sortedBy { it.appLabel.lowercase() }
 
-/** A rule must remain manageable even when a probe, permission or package update hides its target. */
 fun retainConfiguredCandidates(items: List<ComponentCandidate>, selected: Set<ComponentRule>): List<ComponentCandidate> {
     val kept = items.filter { !it.unavailable || it.rule in selected }
     val ids = kept.map { it.rule.id }.toSet()
@@ -161,9 +157,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         if (mutableComponentBusy.value) return
         mutableComponentBusy.value = true
         viewModelScope.launch {
-            try {
-                mutableComponentScan.value = withContext(Dispatchers.IO) { rootCatalog.scan() }
-            } catch (cancelled: CancellationException) { throw cancelled }
+            try { mutableComponentScan.value = withContext(Dispatchers.IO) { rootCatalog.scan() } }
+            catch (cancelled: CancellationException) { throw cancelled }
             catch (failure: Exception) { mutableComponentMessage.value = failure.message ?: "扫描失败" }
             finally { mutableComponentBusy.value = false }
         }
@@ -192,8 +187,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                         result = rootCatalog.change(target, enable)
                         completed++
                     }
-                    mutableComponentMessage.value = if (targets.size == 1) result
-                        else "已核验：${completed} 个组件已${if (enable) "启用" else "禁用"}；请重新打开目标选择器"
+                    mutableComponentMessage.value = if (targets.size == 1) result else "已核验：${completed} 个组件已${if (enable) "启用" else "禁用"}；请重新打开目标选择器"
                 } catch (failure: ComponentRootCommand.RootAccessException) {
                     mutableComponentMessage.value = failure.message
                     mutableComponentRootNotice.value = failure.message
@@ -265,18 +259,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val found = app.catalog.inspectFile(uri)
                 val config = app.rules.remoteSnapshot()
                 val preview = com.yagay.ListCleaner.domain.previewOpenEffect(
-                    candidates = found,
-                    genericSelected = config.rules,
-                    mode = config.mode,
-                    priorities = config.priorities,
-                    openTypes = config.openTypes,
-                    mimeType = mime,
-                    scheme = uri.scheme,
-                    fileNameOrPath = uri.lastPathSegment ?: uri.path
+                    found, config.rules, config.mode, config.priorities, config.openTypes,
+                    mime, uri.scheme, uri.lastPathSegment ?: uri.path
                 )
                 check(app.synchronize()) { app.runtime.value.message }
                 mutableFileCheckStatus.value = buildString {
-                    append("识别类型：${preview.preset?.title ?: "通用打开方式"} · MIME=${mime ?: "未知"}\n")
+                    append("识别类型：${preview.preset?.let(config.openTypes::titleFor) ?: "通用打开方式"} · MIME=${mime ?: "未知"}\n")
                     append("原始候选 ${preview.rawCount} 个 → 预计最终 ${preview.finalCount} 个")
                     if (preview.restoredEmpty) append("（触发空列表保护，恢复系统原结果）")
                     append("。此预览不模拟来源应用自身的私有菜单或同 UID 保护。")
@@ -291,13 +279,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     }
                     if (preview.items.size > details.size) append("\n…另有 ${preview.items.size - details.size} 项，完整候选见诊断包")
                 }
-            } catch (cancelled: CancellationException) {
-                throw cancelled
-            } catch (failure: Exception) {
-                mutableFileCheckStatus.value = failure.message ?: "文件检查失败"
-            } finally {
-                mutableCheckingFile.value = false
-            }
+            } catch (cancelled: CancellationException) { throw cancelled }
+            catch (failure: Exception) { mutableFileCheckStatus.value = failure.message ?: "文件检查失败" }
+            finally { mutableCheckingFile.value = false }
         }
     }
 
@@ -333,8 +317,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     module = freshStatus, selected = config.rules, displayMode = config.mode,
                     priorities = config.priorities, diagnosticMode = config.diagnostic, tiles = config.tiles,
                     openTypes = config.openTypes, openTypesExplicit = config.openTypes, defaultOpen = config.defaultOpen,
-                    runtime = app.runtime.value,
-                    syncStatus = app.syncStatus.value
+                    runtime = app.runtime.value, syncStatus = app.syncStatus.value
                 ), mutableComponentScan.value, rootCatalog.lastOperation)
                 val ready = requireNotNull(report)
                 withContext(Dispatchers.IO) {
@@ -342,14 +325,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     output.use { destination -> ready.inputStream().use { it.copyTo(destination) } }
                 }
                 mutableExportMessage.value = "诊断包已导出"
-            } catch (cancelled: CancellationException) {
-                throw cancelled
-            } catch (failure: Exception) {
-                mutableExportMessage.value = "导出失败：${failure.message}；目标文件可能不完整，请重新导出"
-            } finally {
-                report?.delete()
-                mutableCollectingDiagnostics.value = false
-            }
+            } catch (cancelled: CancellationException) { throw cancelled }
+            catch (failure: Exception) { mutableExportMessage.value = "导出失败：${failure.message}；目标文件可能不完整，请重新导出" }
+            finally { report?.delete(); mutableCollectingDiagnostics.value = false }
         }
     }
 
@@ -368,12 +346,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val content = values[3] as ListContent
         val priorityConfig = values[6] as PriorityConfig
         val rawOpenTypes = values[14] as OpenTypeConfig
-        val genericOpenIds = content.selected.asSequence()
-            .filter { it.kind == IntentKind.OPEN }
-            .map { it.id }
-            .toSet()
+        val genericOpenIds = content.selected.asSequence().filter { it.kind == IntentKind.OPEN }.map { it.id }.toSet()
         val genericOpenPriority = priorityConfig.apps[IntentKind.OPEN].orEmpty()
-        val typedPresets = OpenPreset.entries.filter { it != OpenPreset.BROWSER }
+        val typedPresets = rawOpenTypes.configuredPresets()
         val effectiveRules = typedPresets.mapNotNull { preset ->
             val ids = genericOpenIds + rawOpenTypes.rules[preset].orEmpty()
             if (ids.isEmpty()) null else preset to ids
@@ -385,52 +360,31 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }.toMap()
         val effectiveOpenTypes = rawOpenTypes.copy(rules = effectiveRules, priorities = effectivePriorities)
         MainState(
-            module = values[0] as ModuleStatus,
-            loading = values[1] as Boolean,
-            error = values[2] as String?,
-            candidates = content.candidates,
-            selected = content.selected,
-            runtime = values[4] as RuntimeStatus,
-            displayMode = values[5] as DisplayMode,
-            filter = content.filter,
-            query = content.query,
-            priorities = priorityConfig,
-            groups = content.groups,
-            diagnosticMode = values[7] as Boolean,
-            syncStatus = values[8] as String,
-            destination = values[9] as Destination,
-            expandedAppKey = values[10] as String?,
-            tiles = values[11] as TileConfig,
-            hiddenFromApps = values[12] as Set<String>,
-            defaultOpen = values[13] as DefaultOpenConfig,
-            openTypes = effectiveOpenTypes,
-            openTypesExplicit = rawOpenTypes,
-            uiFilter = content.uiFilter
+            module = values[0] as ModuleStatus, loading = values[1] as Boolean, error = values[2] as String?,
+            candidates = content.candidates, selected = content.selected, runtime = values[4] as RuntimeStatus,
+            displayMode = values[5] as DisplayMode, filter = content.filter, query = content.query,
+            priorities = priorityConfig, groups = content.groups, diagnosticMode = values[7] as Boolean,
+            syncStatus = values[8] as String, destination = values[9] as Destination,
+            expandedAppKey = values[10] as String?, tiles = values[11] as TileConfig,
+            hiddenFromApps = values[12] as Set<String>, defaultOpen = values[13] as DefaultOpenConfig,
+            openTypes = effectiveOpenTypes, openTypesExplicit = rawOpenTypes, uiFilter = content.uiFilter
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), MainState())
 
     init {
         viewModelScope.launch {
-            app.service.collectLatest {
-                readModuleStatus(it)
-                refresh()
-            }
+            app.service.collectLatest { readModuleStatus(it); refresh() }
         }
     }
 
-    fun setDiagnosticMode(enabled: Boolean) {
-        app.rules.setDiagnosticMode(enabled)
-        refreshModuleStatus()
-    }
+    fun setDiagnosticMode(enabled: Boolean) { app.rules.setDiagnosticMode(enabled); refreshModuleStatus() }
+    fun setDefaultOpen(preset: OpenPreset, ruleId: String?) { if (canEdit()) app.rules.setDefaultOpen(preset, ruleId) }
+    fun setHiddenFromApps(packages: Set<String>) { app.rules.setHiddenFromApps(packages); viewModelScope.launch { app.synchronize() } }
 
-    fun setDefaultOpen(preset: OpenPreset, ruleId: String?) {
+    fun setCustomOpenDefinition(preset: OpenPreset, definition: CustomOpenDefinition?) {
         if (!canEdit()) return
-        app.rules.setDefaultOpen(preset, ruleId)
-    }
-
-    fun setHiddenFromApps(packages: Set<String>) {
-        app.rules.setHiddenFromApps(packages)
-        viewModelScope.launch { app.synchronize() }
+        app.rules.setCustomOpenDefinition(preset, definition)
+        refresh()
     }
 
     fun refresh() {
@@ -443,37 +397,22 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val configured = app.rules.rules.value + app.rules.openTypes.value.rules.values.flatten().mapNotNull(ComponentRule::fromId)
                 candidates.value = app.catalog.completeConfigured(candidates.value, configured)
                 check(app.synchronize()) { app.runtime.value.message }
-                val result = app.catalog.scan()
+                val result = app.catalog.scan(app.rules.openTypes.value.customDefinitions)
                 check(app.synchronize()) { app.runtime.value.message }
                 if (generation == refreshGeneration) {
-                    val configured = app.rules.rules.value + app.rules.openTypes.value.rules.values.flatten().mapNotNull(ComponentRule::fromId)
-                    candidates.value = app.catalog.completeConfigured(result, configured)
+                    val updatedConfigured = app.rules.rules.value + app.rules.openTypes.value.rules.values.flatten().mapNotNull(ComponentRule::fromId)
+                    candidates.value = app.catalog.completeConfigured(result, updatedConfigured)
                     error.value = app.catalog.scanWarning
                 }
-            } catch (cancelled: CancellationException) {
-                throw cancelled
-            } catch (failure: Throwable) {
-                if (generation == refreshGeneration) error.value = failure.message ?: "扫描失败"
-            } finally {
-                if (generation == refreshGeneration) loading.value = false
-            }
+            } catch (cancelled: CancellationException) { throw cancelled }
+            catch (failure: Throwable) { if (generation == refreshGeneration) error.value = failure.message ?: "扫描失败" }
+            finally { if (generation == refreshGeneration) loading.value = false }
         }
         refreshModuleStatus()
     }
 
-    fun refreshModuleStatus() {
-        viewModelScope.launch {
-            readModuleStatus(app.service.value)
-            app.synchronize()
-        }
-    }
-
-    fun resolveRecovery(restore: Boolean) {
-        viewModelScope.launch {
-            app.resolveRecovery(restore)
-            refresh()
-        }
-    }
+    fun refreshModuleStatus() { viewModelScope.launch { readModuleStatus(app.service.value); app.synchronize() } }
+    fun resolveRecovery(restore: Boolean) { viewModelScope.launch { app.resolveRecovery(restore); refresh() } }
 
     fun applyModuleUpdate() {
         if (mutableUpdating.value) return
@@ -487,20 +426,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val messages = mutableListOf<String>()
                 for (target in pending) {
                     try {
-                        if (target.state == HookedTarget.State.RELOADING) {
-                            messages += "${target.processName}：框架正在重载，请稍后重新检测"
-                            continue
-                        }
-                        if (target.loadedVersionCode < 19) {
-                            messages += "${target.processName}：旧版本 ${target.loadedVersionCode} 不支持本模块热重载，请完整重启手机"
-                            continue
-                        }
+                        if (target.state == HookedTarget.State.RELOADING) { messages += "${target.processName}：框架正在重载，请稍后重新检测"; continue }
+                        if (target.loadedVersionCode < 19) { messages += "${target.processName}：旧版本 ${target.loadedVersionCode} 不支持本模块热重载，请完整重启手机"; continue }
                         val result = withTimeoutOrNull(15_000) {
                             withContext(Dispatchers.IO) {
                                 suspendCancellableCoroutine<HotReloadResult> { continuation ->
-                                    bound.hotReloadModule(target, null) { _, reply ->
-                                        if (continuation.isActive) continuation.resume(reply)
-                                    }
+                                    bound.hotReloadModule(target, null) { _, reply -> if (continuation.isActive) continuation.resume(reply) }
                                 }
                             }
                         }
@@ -512,19 +443,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                             HotReloadResult.Status.IN_PROGRESS -> "框架正在重载，请稍后重新检测"
                             null -> "等待超时，不代表已取消；请重新检测，勿重复请求"
                         }
-                    } catch (cancelled: CancellationException) {
-                        throw cancelled
-                    } catch (failure: Exception) {
-                        messages += "${target.processName}：更新请求失败（${failure.javaClass.simpleName}）；继续检查其他目标"
-                    }
+                    } catch (cancelled: CancellationException) { throw cancelled }
+                    catch (failure: Exception) { messages += "${target.processName}：更新请求失败（${failure.javaClass.simpleName}）；继续检查其他目标" }
                 }
                 mutableUpdateMessage.value = if (messages.isEmpty()) "没有需要热更新的运行目标；正在核实配置" else messages.joinToString("\n")
                 refresh()
-            } catch (cancelled: CancellationException) {
-                throw cancelled
-            } catch (failure: Exception) {
-                mutableUpdateMessage.value = "更新检查失败：${failure.message}；未重启任何系统进程"
-            } finally { mutableUpdating.value = false }
+            } catch (cancelled: CancellationException) { throw cancelled }
+            catch (failure: Exception) { mutableUpdateMessage.value = "更新检查失败：${failure.message}；未重启任何系统进程" }
+            finally { mutableUpdating.value = false }
         }
     }
 
@@ -535,24 +461,16 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             var result = ModuleStatus(connected = service != null, detection = detection)
             if (service != null) {
                 try {
-                    result = result.copy(apiVersion = service.apiVersion)
-                    result = result.copy(grantedScope = service.scope.toSet(), scopeKnown = true)
-                    result = if ((result.apiVersion ?: 0) >= 102) {
-                        result.copy(runningTargets = service.runningTargets.map {
-                            RunningTargetStatus(it.processName, it.state.name, it.loadedVersionCode)
-                        })
-                    } else result.copy(error = "当前框架不支持运行目标检测")
-                } catch (cancelled: CancellationException) {
-                    throw cancelled
-                } catch (failure: Exception) {
-                    result = result.copy(error = failure.message ?: "无法读取 LSPosed 模块状态")
-                }
+                    result = result.copy(apiVersion = service.apiVersion, grantedScope = service.scope.toSet(), scopeKnown = true)
+                    result = if ((result.apiVersion ?: 0) >= 102) result.copy(runningTargets = service.runningTargets.map {
+                        RunningTargetStatus(it.processName, it.state.name, it.loadedVersionCode)
+                    }) else result.copy(error = "当前框架不支持运行目标检测")
+                } catch (cancelled: CancellationException) { throw cancelled }
+                catch (failure: Exception) { result = result.copy(error = failure.message ?: "无法读取 LSPosed 模块状态") }
             }
             result
         }
-        if (generation == statusGeneration && app.service.value === service) {
-            moduleStatus.value = status.copy(requesting = scopeRequestInFlight)
-        }
+        if (generation == statusGeneration && app.service.value === service) moduleStatus.value = status.copy(requesting = scopeRequestInFlight)
         return status
     }
 
@@ -560,9 +478,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         if (!it) error.value = "请先完成远程配置恢复或重置，避免覆盖原有规则"
     }
 
-    private fun genericOpenSelected(): Set<ComponentRule> =
-        app.rules.rules.value.filterTo(linkedSetOf()) { it.kind == IntentKind.OPEN }
-
+    private fun genericOpenSelected(): Set<ComponentRule> = app.rules.rules.value.filterTo(linkedSetOf()) { it.kind == IntentKind.OPEN }
     private fun openTypePriorityBase(preset: OpenPreset): List<String> {
         val explicit = app.rules.openTypes.value.priorities[preset].orEmpty()
         return if (explicit.isNotEmpty()) explicit else app.rules.priorities.value.apps[IntentKind.OPEN].orEmpty()
@@ -570,41 +486,24 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun toggle(rule: ComponentRule) { if (canEdit()) app.rules.toggle(rule) }
     fun setGroupSelected(group: AppGroup, selected: Boolean) { if (canEdit()) app.rules.setSelected(group.components.map { it.rule }, selected) }
-
-    fun toggleOpenType(preset: OpenPreset, rule: ComponentRule) {
-        if (!canEdit() || rule in genericOpenSelected()) return
-        app.rules.toggleOpenType(preset, rule)
-    }
-
+    fun toggleOpenType(preset: OpenPreset, rule: ComponentRule) { if (canEdit() && rule !in genericOpenSelected()) app.rules.toggleOpenType(preset, rule) }
     fun setOpenTypeGroupSelected(preset: OpenPreset, group: AppGroup, selected: Boolean) {
         if (!canEdit()) return
-        val inherited = genericOpenSelected()
-        val editable = group.components.map { it.rule }.filterNot { it in inherited }
+        val editable = group.components.map { it.rule }.filterNot { it in genericOpenSelected() }
         if (editable.isNotEmpty()) app.rules.setOpenTypeSelected(preset, editable, selected)
     }
-
     fun selectOpenTypeRules(preset: OpenPreset, rules: Collection<ComponentRule>) {
         if (!canEdit() || rules.isEmpty()) return
-        val inherited = genericOpenSelected()
-        val editable = rules.distinct().filterNot { it in inherited }
+        val editable = rules.distinct().filterNot { it in genericOpenSelected() }
         if (editable.isNotEmpty()) app.rules.setOpenTypeSelected(preset, editable, true)
     }
-
     fun invertOpenTypeRules(preset: OpenPreset, rules: Collection<ComponentRule>) {
         if (!canEdit() || rules.isEmpty()) return
-        val inherited = genericOpenSelected()
-        val editable = rules.distinct().filterNot { it in inherited }
+        val editable = rules.distinct().filterNot { it in genericOpenSelected() }
         if (editable.isNotEmpty()) app.rules.invertOpenTypeSelected(preset, editable)
     }
-
-    fun selectRules(rules: Collection<ComponentRule>) {
-        if (!canEdit() || rules.isEmpty()) return
-        app.rules.setSelected(rules.distinct(), true)
-    }
-    fun invertRules(rules: Collection<ComponentRule>) {
-        if (!canEdit() || rules.isEmpty()) return
-        app.rules.invertSelected(rules)
-    }
+    fun selectRules(rules: Collection<ComponentRule>) { if (canEdit() && rules.isNotEmpty()) app.rules.setSelected(rules.distinct(), true) }
+    fun invertRules(rules: Collection<ComponentRule>) { if (canEdit() && rules.isNotEmpty()) app.rules.invertSelected(rules) }
     fun setDisplayMode(value: DisplayMode) { if (canEdit()) app.rules.setDisplayMode(value) }
     fun setFilter(value: IntentKind?) { filter.value = value }
     fun setQuery(value: String) { query.value = value }
@@ -613,51 +512,33 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun toggleExpandedApp(key: String) { expandedAppKey.value = if (expandedAppKey.value == key) null else key }
     fun exportJson(): String = app.rules.exportJson()
     fun importJson(content: String) = app.rules.importJson(content)
-    fun setComponentTitle(ruleId: String, title: String?) {
-        if (canEdit()) app.rules.setComponentTitle(ruleId, title)
-    }
+    fun setComponentTitle(ruleId: String, title: String?) { if (canEdit()) app.rules.setComponentTitle(ruleId, title) }
 
     fun selectPriorityApps(kind: IntentKind, packageNames: Collection<String>) {
         if (!canEdit()) return
         val current = app.rules.priorities.value.apps[kind].orEmpty()
-        val additions = packageNames.distinct().filter { it !in current }
-        val next = (current + additions).take(200)
+        val next = (current + packageNames.distinct().filter { it !in current }).take(200)
         if (next != current) app.rules.setPriority(kind, next)
     }
-
     fun invertPriorityApps(kind: IntentKind, packageNames: Collection<String>) {
         if (!canEdit()) return
-        val visible = packageNames.distinct()
-        if (visible.isEmpty()) return
-        val visibleSet = visible.toSet()
+        val visible = packageNames.distinct(); if (visible.isEmpty()) return
         val current = app.rules.priorities.value.apps[kind].orEmpty()
-        val retained = current.filterNot { it in visibleSet }
-        val added = visible.filter { it !in current }
-        val next = (retained + added).take(200)
+        val next = (current.filterNot { it in visible.toSet() } + visible.filter { it !in current }).take(200)
         if (next != current) app.rules.setPriority(kind, next)
     }
-
     fun pinApp(kind: IntentKind, packageName: String) {
         if (!canEdit()) return
         val current = app.rules.priorities.value.apps[kind].orEmpty()
         if (packageName !in current && current.size < 200) app.rules.setPriority(kind, current + packageName)
     }
-
-    fun removePriority(kind: IntentKind, packageName: String) {
-        if (!canEdit()) return
-        app.rules.setPriority(kind, app.rules.priorities.value.apps[kind].orEmpty() - packageName)
-    }
-
+    fun removePriority(kind: IntentKind, packageName: String) { if (canEdit()) app.rules.setPriority(kind, app.rules.priorities.value.apps[kind].orEmpty() - packageName) }
     fun movePriority(kind: IntentKind, packageName: String, offset: Int, visible: List<String>) {
-        if (!canEdit()) return
-        val current = app.rules.priorities.value.apps[kind].orEmpty()
-        app.rules.setPriority(kind, com.yagay.ListCleaner.domain.moveVisiblePriority(current, visible, packageName, offset))
+        if (canEdit()) app.rules.setPriority(kind, com.yagay.ListCleaner.domain.moveVisiblePriority(app.rules.priorities.value.apps[kind].orEmpty(), visible, packageName, offset))
     }
-
     fun movePriorityTo(kind: IntentKind, packageName: String, target: String, visible: List<String>, expected: List<String>) {
         if (!canEdit()) return
-        val current = app.rules.priorities.value.apps[kind].orEmpty()
-        if (current != expected) return
+        val current = app.rules.priorities.value.apps[kind].orEmpty(); if (current != expected) return
         val updated = com.yagay.ListCleaner.domain.moveVisiblePriorityTo(current, visible, packageName, target)
         if (updated != current) app.rules.setPriority(kind, updated)
     }
@@ -668,48 +549,36 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val next = (current + packageNames.distinct().filter { it !in current }).take(200)
         if (next != current) app.rules.setOpenTypePriority(preset, next)
     }
-
     fun invertOpenTypePriorityApps(preset: OpenPreset, packageNames: Collection<String>) {
         if (!canEdit()) return
-        val visible = packageNames.distinct()
-        if (visible.isEmpty()) return
+        val visible = packageNames.distinct(); if (visible.isEmpty()) return
         val current = openTypePriorityBase(preset)
-        val retained = current.filterNot { it in visible.toSet() }
-        val next = (retained + visible.filter { it !in current }).take(200)
+        val next = (current.filterNot { it in visible.toSet() } + visible.filter { it !in current }).take(200)
         if (next != current) app.rules.setOpenTypePriority(preset, next)
     }
-
     fun pinOpenTypeApp(preset: OpenPreset, packageName: String) {
         if (!canEdit()) return
         val current = openTypePriorityBase(preset)
         if (packageName !in current && current.size < 200) app.rules.setOpenTypePriority(preset, current + packageName)
     }
-
     fun removeOpenTypePriority(preset: OpenPreset, packageName: String) {
         if (!canEdit()) return
-        val current = openTypePriorityBase(preset)
-        val next = current - packageName
+        val current = openTypePriorityBase(preset); val next = current - packageName
         if (next != current) app.rules.setOpenTypePriority(preset, next)
     }
-
     fun moveOpenTypePriority(preset: OpenPreset, packageName: String, offset: Int, visible: List<String>) {
         if (!canEdit()) return
         val current = openTypePriorityBase(preset)
         val updated = com.yagay.ListCleaner.domain.moveVisiblePriority(current, visible, packageName, offset)
         if (updated != current) app.rules.setOpenTypePriority(preset, updated)
     }
-
     fun moveOpenTypePriorityTo(preset: OpenPreset, packageName: String, target: String, visible: List<String>, expected: List<String>) {
         if (!canEdit()) return
-        val current = openTypePriorityBase(preset)
-        if (current != expected) return
+        val current = openTypePriorityBase(preset); if (current != expected) return
         val updated = com.yagay.ListCleaner.domain.moveVisiblePriorityTo(current, visible, packageName, target)
         if (updated != current) app.rules.setOpenTypePriority(preset, updated)
     }
-
-    fun resetOpenTypePriority(preset: OpenPreset) {
-        if (canEdit()) app.rules.setOpenTypePriority(preset, emptyList())
-    }
+    fun resetOpenTypePriority(preset: OpenPreset) { if (canEdit()) app.rules.setOpenTypePriority(preset, emptyList()) }
 
     fun requestScope() {
         if (scopeRequestInFlight) return
@@ -723,25 +592,17 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 check(current.scopeKnown) { current.error ?: "无法读取已授权作用域，未提交申请" }
                 check(current.detection.recommended.isNotEmpty()) { "未确认可自动申请的选择器宿主，请查看检测详情并在 LSPosed 中手动核查" }
                 val missing = current.missingScope.toList()
-                if (missing.isEmpty()) {
-                    moduleStatus.value = current.copy(requesting = true, message = "检测到的推荐作用域均已授权，无需重复申请")
-                    return@launch
-                }
+                if (missing.isEmpty()) { moduleStatus.value = current.copy(requesting = true, message = "检测到的推荐作用域均已授权，无需重复申请"); return@launch }
                 val approved = withTimeoutOrNull(120_000) {
                     suspendCancellableCoroutine<List<String>> { continuation ->
                         service.requestScope(missing, object : XposedService.OnScopeEventListener {
-                            override fun onScopeRequestApproved(approved: List<String>) {
-                                if (continuation.isActive) continuation.resume(approved)
-                            }
-                            override fun onScopeRequestFailed(message: String) {
-                                if (continuation.isActive) continuation.resumeWithException(IllegalStateException(message))
-                            }
+                            override fun onScopeRequestApproved(approved: List<String>) { if (continuation.isActive) continuation.resume(approved) }
+                            override fun onScopeRequestFailed(message: String) { if (continuation.isActive) continuation.resumeWithException(IllegalStateException(message)) }
                         })
                     }
                 }
                 check(app.service.value === service) { "服务连接已变化，请重新检查授权结果" }
                 val refreshed = readModuleStatus(service)
-                check(app.service.value === service) { "服务连接已变化，请重新检查授权结果" }
                 val message = when {
                     approved == null -> "等待授权超时，框架申请可能仍在处理；请先在 LSPosed 查看结果"
                     !refreshed.scopeKnown -> "框架已返回，暂时无法核实授权结果，请重新检查"
@@ -749,20 +610,13 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     else -> "推荐作用域已确认授权；若目标尚未加载，请重新启动相关选择器，必要时重启设备"
                 }
                 moduleStatus.value = refreshed.copy(message = message)
-            } catch (cancelled: CancellationException) {
-                throw cancelled
-            } catch (failure: Exception) {
-                moduleStatus.value = moduleStatus.value.copy(error = failure.message ?: "申请作用域失败")
-            } finally {
-                scopeRequestInFlight = false
-                moduleStatus.value = moduleStatus.value.copy(requesting = false)
-            }
+            } catch (cancelled: CancellationException) { throw cancelled }
+            catch (failure: Exception) { moduleStatus.value = moduleStatus.value.copy(error = failure.message ?: "申请作用域失败") }
+            finally { scopeRequestInFlight = false; moduleStatus.value = moduleStatus.value.copy(requesting = false) }
         }
     }
 
-    companion object {
-        const val MAX_BACKUP_CHARS = RuleRepository.MAX_BACKUP_CHARS
-    }
+    companion object { const val MAX_BACKUP_CHARS = RuleRepository.MAX_BACKUP_CHARS }
 }
 
 internal fun catalogVisible(item: ComponentCandidate, selected: Boolean, uiFilter: UiFilter): Boolean =

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
@@ -170,7 +170,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun changeComponents(visibleTargets: List<RootComponent>, enable: Boolean) {
         if (mutableComponentBusy.value) return
-        // Snapshot only the visible, editable components. A component can match multiple kinds.
         val targets = visibleTargets.filter { it.blocked == null && it.enabled != null && it.enabled != enable }
             .distinctBy { "${it.user}|${it.component.flattenToString()}" }
         if (targets.isEmpty()) return
@@ -178,7 +177,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         mutableComponentBusy.value = true
         mutableComponentMessage.value = "正在请求 Root 并核验系统状态…"
         viewModelScope.launch {
-            // Finish observation even if navigation/lifecycle cancels the awaiting UI.
             withContext(kotlinx.coroutines.NonCancellable + Dispatchers.IO) {
                 var completed = 0
                 var operationStarted = false
@@ -197,13 +195,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     mutableComponentMessage.value = failure.message
                     mutableComponentRootNotice.value = failure.message
                 } catch (failure: Exception) {
-                    // Stop on failure: do not repeatedly prompt for Root or claim an atomic batch.
                     mutableComponentMessage.value = "已完成 $completed/${targets.size}，操作已停止：${failure.message ?: "操作失败"}。失败项请核对系统状态；剩余项未执行，已完成项不回滚。"
                 } finally {
                     if (operationStarted) runCatching { rootCatalog.scan() }.onSuccess { mutableComponentScan.value = it }
-                        .onFailure {
-                            mutableComponentScan.value = RootComponentScan(warning = "操作后扫描失败，请刷新；不使用旧状态")
-                        }
+                        .onFailure { mutableComponentScan.value = RootComponentScan(warning = "操作后扫描失败，请刷新；不使用旧状态") }
                     mutableComponentBusy.value = false
                 }
             }
@@ -301,8 +296,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             var report: File? = null
             try {
-                // Rescue path: never wait for the sync mutex, PM probes or framework IPC.
-                // Export the last observed status with its age, then collect raw logs independently.
                 val freshStatus = moduleStatus.value
                 val config = app.rules.remoteSnapshot()
                 report = DiagnosticCollector.collect(app, state.value.copy(
@@ -336,23 +329,42 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val items = retainConfiguredCandidates(scanned, selected)
         ListContent(items, kind, text, groupCandidates(items, selected, kind, text, ui), selected, ui)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListContent(emptyList(), null, "", emptyList()))
-    
+
     val state: StateFlow<MainState> = combine(
         moduleStatus, loading, error, grouped, app.runtime, app.rules.displayMode, app.rules.priorities, app.rules.diagnosticMode, app.syncStatus, destination, expandedAppKey, app.rules.tiles, app.rules.hiddenFromApps, app.rules.defaultOpen, app.rules.openTypes
     ) { values ->
         @Suppress("UNCHECKED_CAST")
+        val content = values[3] as ListContent
+        val priorityConfig = values[6] as PriorityConfig
+        val rawOpenTypes = values[14] as OpenTypeConfig
+        val genericOpenIds = content.selected.asSequence()
+            .filter { it.kind == IntentKind.OPEN }
+            .map { it.id }
+            .toSet()
+        val genericOpenPriority = priorityConfig.apps[IntentKind.OPEN].orEmpty()
+        val typedPresets = OpenPreset.entries.filter { it != OpenPreset.BROWSER }
+        val effectiveRules = typedPresets.mapNotNull { preset ->
+            val ids = genericOpenIds + rawOpenTypes.rules[preset].orEmpty()
+            if (ids.isEmpty()) null else preset to ids
+        }.toMap()
+        val effectivePriorities = typedPresets.mapNotNull { preset ->
+            val explicit = rawOpenTypes.priorities[preset].orEmpty()
+            val packages = if (explicit.isNotEmpty()) explicit else genericOpenPriority
+            if (packages.isEmpty()) null else preset to packages
+        }.toMap()
+        val effectiveOpenTypes = rawOpenTypes.copy(rules = effectiveRules, priorities = effectivePriorities)
         MainState(
             module = values[0] as ModuleStatus,
             loading = values[1] as Boolean,
             error = values[2] as String?,
-            candidates = (values[3] as ListContent).candidates,
-            selected = (values[3] as ListContent).selected,
+            candidates = content.candidates,
+            selected = content.selected,
             runtime = values[4] as RuntimeStatus,
             displayMode = values[5] as DisplayMode,
-            filter = (values[3] as ListContent).filter,
-            query = (values[3] as ListContent).query,
-            priorities = values[6] as PriorityConfig,
-            groups = (values[3] as ListContent).groups,
+            filter = content.filter,
+            query = content.query,
+            priorities = priorityConfig,
+            groups = content.groups,
             diagnosticMode = values[7] as Boolean,
             syncStatus = values[8] as String,
             destination = values[9] as Destination,
@@ -360,8 +372,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             tiles = values[11] as TileConfig,
             hiddenFromApps = values[12] as Set<String>,
             defaultOpen = values[13] as DefaultOpenConfig,
-            openTypes = values[14] as OpenTypeConfig,
-            uiFilter = (values[3] as ListContent).uiFilter
+            openTypes = effectiveOpenTypes,
+            uiFilter = content.uiFilter
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), MainState())
 
@@ -402,7 +414,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val result = app.catalog.scan()
                 check(app.synchronize()) { app.runtime.value.message }
                 if (generation == refreshGeneration) {
-                    // Replace the directory, do not accumulate historical scan results.
                     val configured = app.rules.rules.value + app.rules.openTypes.value.rules.values.flatten().mapNotNull(ComponentRule::fromId)
                     candidates.value = app.catalog.completeConfigured(result, configured)
                     error.value = app.catalog.scanWarning
@@ -444,31 +455,31 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val messages = mutableListOf<String>()
                 for (target in pending) {
                     try {
-                    if (target.state == HookedTarget.State.RELOADING) {
-                        messages += "${target.processName}：框架正在重载，请稍后重新检测"
-                        continue
-                    }
-                    if (target.loadedVersionCode < 19) {
-                        messages += "${target.processName}：旧版本 ${target.loadedVersionCode} 不支持本模块热重载，请完整重启手机"
-                        continue
-                    }
-                    val result = withTimeoutOrNull(15_000) {
-                        withContext(Dispatchers.IO) {
-                            suspendCancellableCoroutine<HotReloadResult> { continuation ->
-                                bound.hotReloadModule(target, null) { _, reply ->
-                                    if (continuation.isActive) continuation.resume(reply)
+                        if (target.state == HookedTarget.State.RELOADING) {
+                            messages += "${target.processName}：框架正在重载，请稍后重新检测"
+                            continue
+                        }
+                        if (target.loadedVersionCode < 19) {
+                            messages += "${target.processName}：旧版本 ${target.loadedVersionCode} 不支持本模块热重载，请完整重启手机"
+                            continue
+                        }
+                        val result = withTimeoutOrNull(15_000) {
+                            withContext(Dispatchers.IO) {
+                                suspendCancellableCoroutine<HotReloadResult> { continuation ->
+                                    bound.hotReloadModule(target, null) { _, reply ->
+                                        if (continuation.isActive) continuation.resume(reply)
+                                    }
                                 }
                             }
                         }
-                    }
-                    messages += "${target.processName}：" + when (result?.status()) {
-                        HotReloadResult.Status.SUCCEEDED -> "框架报告更新成功，正在重新核实"
-                        HotReloadResult.Status.UNSUPPORTED -> "框架不支持，请重启手机"
-                        HotReloadResult.Status.FAILED -> "更新失败：${result?.message() ?: "旧模块拒绝"}；请重启手机"
-                        HotReloadResult.Status.PROCESS_DIED -> "目标已退出，等待重新启动"
-                        HotReloadResult.Status.IN_PROGRESS -> "框架正在重载，请稍后重新检测"
-                        null -> "等待超时，不代表已取消；请重新检测，勿重复请求"
-                    }
+                        messages += "${target.processName}：" + when (result?.status()) {
+                            HotReloadResult.Status.SUCCEEDED -> "框架报告更新成功，正在重新核实"
+                            HotReloadResult.Status.UNSUPPORTED -> "框架不支持，请重启手机"
+                            HotReloadResult.Status.FAILED -> "更新失败：${result?.message() ?: "旧模块拒绝"}；请重启手机"
+                            HotReloadResult.Status.PROCESS_DIED -> "目标已退出，等待重新启动"
+                            HotReloadResult.Status.IN_PROGRESS -> "框架正在重载，请稍后重新检测"
+                            null -> "等待超时，不代表已取消；请重新检测，勿重复请求"
+                        }
                     } catch (cancelled: CancellationException) {
                         throw cancelled
                     } catch (failure: Exception) {
@@ -516,18 +527,47 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private fun canEdit(): Boolean = app.rules.hasLocalConfiguration().also {
         if (!it) error.value = "请先完成远程配置恢复或重置，避免覆盖原有规则"
     }
+
+    private fun genericOpenSelected(): Set<ComponentRule> =
+        app.rules.rules.value.filterTo(linkedSetOf()) { it.kind == IntentKind.OPEN }
+
+    private fun explicitOpenTypeRules(preset: OpenPreset): Set<ComponentRule> =
+        app.rules.openTypes.value.rules[preset].orEmpty().mapNotNullTo(linkedSetOf(), ComponentRule::fromId)
+
+    private fun openTypePriorityBase(preset: OpenPreset): List<String> {
+        val explicit = app.rules.openTypes.value.priorities[preset].orEmpty()
+        return if (explicit.isNotEmpty()) explicit else app.rules.priorities.value.apps[IntentKind.OPEN].orEmpty()
+    }
+
     fun toggle(rule: ComponentRule) { if (canEdit()) app.rules.toggle(rule) }
     fun setGroupSelected(group: AppGroup, selected: Boolean) { if (canEdit()) app.rules.setSelected(group.components.map { it.rule }, selected) }
-    fun toggleOpenType(preset: OpenPreset, rule: ComponentRule) { if (canEdit()) app.rules.toggleOpenType(preset, rule) }
+
+    fun toggleOpenType(preset: OpenPreset, rule: ComponentRule) {
+        if (!canEdit() || rule in genericOpenSelected()) return
+        app.rules.toggleOpenType(preset, rule)
+    }
+
     fun setOpenTypeGroupSelected(preset: OpenPreset, group: AppGroup, selected: Boolean) {
-        if (canEdit()) app.rules.setOpenTypeSelected(preset, group.components.map { it.rule }, selected)
+        if (!canEdit()) return
+        val inherited = genericOpenSelected()
+        val editable = group.components.map { it.rule }.filterNot { it in inherited }
+        if (editable.isNotEmpty()) app.rules.setOpenTypeSelected(preset, editable, selected)
     }
+
     fun selectOpenTypeRules(preset: OpenPreset, rules: Collection<ComponentRule>) {
-        if (canEdit() && rules.isNotEmpty()) app.rules.setOpenTypeSelected(preset, rules.distinct(), true)
+        if (!canEdit() || rules.isEmpty()) return
+        val inherited = genericOpenSelected()
+        val editable = rules.distinct().filterNot { it in inherited }
+        if (editable.isNotEmpty()) app.rules.setOpenTypeSelected(preset, editable, true)
     }
+
     fun invertOpenTypeRules(preset: OpenPreset, rules: Collection<ComponentRule>) {
-        if (canEdit() && rules.isNotEmpty()) app.rules.invertOpenTypeSelected(preset, rules)
+        if (!canEdit() || rules.isEmpty()) return
+        val inherited = genericOpenSelected()
+        val editable = rules.distinct().filterNot { it in inherited }
+        if (editable.isNotEmpty()) app.rules.invertOpenTypeSelected(preset, editable)
     }
+
     fun selectRules(rules: Collection<ComponentRule>) {
         if (!canEdit() || rules.isEmpty()) return
         app.rules.setSelected(rules.distinct(), true)
@@ -585,11 +625,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         app.rules.setPriority(kind, com.yagay.ListCleaner.domain.moveVisiblePriority(current, visible, packageName, offset))
     }
 
-
     fun movePriorityTo(kind: IntentKind, packageName: String, target: String, visible: List<String>, expected: List<String>) {
         if (!canEdit()) return
         val current = app.rules.priorities.value.apps[kind].orEmpty()
-        // A drag is a snapshot. Never overwrite a reset/import/edit that occurred during it.
         if (current != expected) return
         val updated = com.yagay.ListCleaner.domain.moveVisiblePriorityTo(current, visible, packageName, target)
         if (updated != current) app.rules.setPriority(kind, updated)
@@ -597,34 +635,44 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun selectOpenTypePriorityApps(preset: OpenPreset, packageNames: Collection<String>) {
         if (!canEdit()) return
-        val current = app.rules.openTypes.value.priorities[preset].orEmpty()
+        val current = openTypePriorityBase(preset)
         val next = (current + packageNames.distinct().filter { it !in current }).take(200)
         if (next != current) app.rules.setOpenTypePriority(preset, next)
     }
+
     fun invertOpenTypePriorityApps(preset: OpenPreset, packageNames: Collection<String>) {
         if (!canEdit()) return
-        val visible = packageNames.distinct(); if (visible.isEmpty()) return
-        val current = app.rules.openTypes.value.priorities[preset].orEmpty()
+        val visible = packageNames.distinct()
+        if (visible.isEmpty()) return
+        val current = openTypePriorityBase(preset)
         val retained = current.filterNot { it in visible.toSet() }
         val next = (retained + visible.filter { it !in current }).take(200)
         if (next != current) app.rules.setOpenTypePriority(preset, next)
     }
+
     fun pinOpenTypeApp(preset: OpenPreset, packageName: String) {
         if (!canEdit()) return
-        val current = app.rules.openTypes.value.priorities[preset].orEmpty()
+        val current = openTypePriorityBase(preset)
         if (packageName !in current && current.size < 200) app.rules.setOpenTypePriority(preset, current + packageName)
     }
+
     fun removeOpenTypePriority(preset: OpenPreset, packageName: String) {
-        if (canEdit()) app.rules.setOpenTypePriority(preset, app.rules.openTypes.value.priorities[preset].orEmpty() - packageName)
+        if (!canEdit()) return
+        val current = openTypePriorityBase(preset)
+        val next = current - packageName
+        if (next != current) app.rules.setOpenTypePriority(preset, next)
     }
+
     fun moveOpenTypePriority(preset: OpenPreset, packageName: String, offset: Int, visible: List<String>) {
         if (!canEdit()) return
-        val current = app.rules.openTypes.value.priorities[preset].orEmpty()
-        app.rules.setOpenTypePriority(preset, com.yagay.ListCleaner.domain.moveVisiblePriority(current, visible, packageName, offset))
+        val current = openTypePriorityBase(preset)
+        val updated = com.yagay.ListCleaner.domain.moveVisiblePriority(current, visible, packageName, offset)
+        if (updated != current) app.rules.setOpenTypePriority(preset, updated)
     }
+
     fun moveOpenTypePriorityTo(preset: OpenPreset, packageName: String, target: String, visible: List<String>, expected: List<String>) {
         if (!canEdit()) return
-        val current = app.rules.openTypes.value.priorities[preset].orEmpty()
+        val current = openTypePriorityBase(preset)
         if (current != expected) return
         val updated = com.yagay.ListCleaner.domain.moveVisiblePriorityTo(current, visible, packageName, target)
         if (updated != current) app.rules.setOpenTypePriority(preset, updated)

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
@@ -14,11 +14,8 @@ import androidx.lifecycle.viewModelScope
 import com.yagay.ListCleaner.BuildConfig
 import com.yagay.ListCleaner.ListCleanerApp
 import com.yagay.ListCleaner.RuntimeStatus
-import com.yagay.ListCleaner.data.ComponentRootCommand
 import com.yagay.ListCleaner.data.ResolverScopeDetector
 import com.yagay.ListCleaner.data.RootComponent
-import com.yagay.ListCleaner.data.RootComponentCatalog
-import com.yagay.ListCleaner.data.RootComponentScan
 import com.yagay.ListCleaner.data.RuleRepository
 import com.yagay.ListCleaner.data.ScopeDetection
 import com.yagay.ListCleaner.domain.ComponentCandidate
@@ -161,116 +158,18 @@ fun retainConfiguredCandidates(
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val app = application as ListCleanerApp
-    private val rootCatalog = RootComponentCatalog(app)
+    private val rootComponents = RootComponentsController(app, viewModelScope)
 
-    private val mutableComponentScan = MutableStateFlow(RootComponentScan())
-    val componentScan: StateFlow<RootComponentScan> = mutableComponentScan
-    private val mutableComponentBusy = MutableStateFlow(false)
-    val componentBusy: StateFlow<Boolean> = mutableComponentBusy
-    private val mutableComponentMessage = MutableStateFlow<String?>(null)
-    val componentMessage: StateFlow<String?> = mutableComponentMessage
-    private val mutableComponentRootNotice = MutableStateFlow<String?>(null)
-    val componentRootNotice: StateFlow<String?> = mutableComponentRootNotice
+    val componentScan = rootComponents.scan
+    val componentBusy = rootComponents.busy
+    val componentMessage = rootComponents.message
+    val componentRootNotice = rootComponents.rootNotice
 
-    fun dismissComponentRootNotice() { mutableComponentRootNotice.value = null }
-
-    fun refreshComponents() {
-        if (mutableComponentBusy.value) return
-        mutableComponentBusy.value = true
-        viewModelScope.launch {
-            try {
-                mutableComponentScan.value = withContext(Dispatchers.IO) { rootCatalog.scan() }
-            } catch (cancelled: CancellationException) {
-                throw cancelled
-            } catch (failure: Exception) {
-                mutableComponentMessage.value = failure.message ?: "扫描失败"
-            } finally {
-                mutableComponentBusy.value = false
-            }
-        }
-    }
-
-    fun changeComponent(target: RootComponent, enable: Boolean) = changeComponents(listOf(target), enable)
-
-    fun changeComponents(visibleTargets: List<RootComponent>, enable: Boolean) {
-        if (mutableComponentBusy.value) return
-        val targets = visibleTargets.filter {
-            it.blocked == null && it.enabled != null && it.enabled != enable
-        }.distinctBy { "${it.user}|${it.component.flattenToString()}" }
-        if (targets.isEmpty()) return
-        mutableComponentRootNotice.value = null
-        mutableComponentBusy.value = true
-        mutableComponentMessage.value = "正在请求 Root 并核验系统状态…"
-        viewModelScope.launch {
-            withContext(kotlinx.coroutines.NonCancellable + Dispatchers.IO) {
-                var completed = 0
-                var operationStarted = false
-                try {
-                    rootCatalog.requireRoot()
-                    var result = ""
-                    for (target in targets) {
-                        operationStarted = true
-                        mutableComponentMessage.value = "正在${if (enable) "启用" else "禁用"} ${completed + 1}/${targets.size}：${target.label}"
-                        result = rootCatalog.change(target, enable)
-                        completed++
-                    }
-                    mutableComponentMessage.value = if (targets.size == 1) result
-                    else "已核验：$completed 个组件已${if (enable) "启用" else "禁用"}；请重新打开目标选择器"
-                } catch (failure: ComponentRootCommand.RootAccessException) {
-                    mutableComponentMessage.value = failure.message
-                    mutableComponentRootNotice.value = failure.message
-                } catch (failure: Exception) {
-                    mutableComponentMessage.value = "已完成 $completed/${targets.size}，操作已停止：${failure.message ?: "操作失败"}。失败项请核对系统状态；剩余项未执行，已完成项不回滚。"
-                } finally {
-                    if (operationStarted) {
-                        runCatching { rootCatalog.scan() }
-                            .onSuccess { mutableComponentScan.value = it }
-                            .onFailure { mutableComponentScan.value = RootComponentScan(warning = "操作后扫描失败，请刷新；不使用旧状态") }
-                    }
-                    mutableComponentBusy.value = false
-                }
-            }
-        }
-    }
-
-    fun invertComponents(visibleTargets: List<RootComponent>) {
-        if (mutableComponentBusy.value) return
-        val targets = visibleTargets.filter {
-            it.blocked == null && it.enabled != null
-        }.distinctBy { "${it.user}|${it.component.flattenToString()}" }
-        if (targets.isEmpty()) return
-        mutableComponentRootNotice.value = null
-        mutableComponentBusy.value = true
-        mutableComponentMessage.value = "正在请求 Root 并反选组件…"
-        viewModelScope.launch {
-            withContext(kotlinx.coroutines.NonCancellable + Dispatchers.IO) {
-                var completed = 0
-                var operationStarted = false
-                try {
-                    rootCatalog.requireRoot()
-                    for (target in targets) {
-                        operationStarted = true
-                        mutableComponentMessage.value = "正在反选 ${completed + 1}/${targets.size}：${target.label}"
-                        rootCatalog.change(target, target.enabled == false)
-                        completed++
-                    }
-                    mutableComponentMessage.value = "已核验：$completed 个组件已反选；请重新打开目标选择器"
-                } catch (failure: ComponentRootCommand.RootAccessException) {
-                    mutableComponentMessage.value = failure.message
-                    mutableComponentRootNotice.value = failure.message
-                } catch (failure: Exception) {
-                    mutableComponentMessage.value = "已完成 $completed/${targets.size}，反选已停止：${failure.message ?: "操作失败"}。已完成项不回滚。"
-                } finally {
-                    if (operationStarted) {
-                        runCatching { rootCatalog.scan() }
-                            .onSuccess { mutableComponentScan.value = it }
-                            .onFailure { mutableComponentScan.value = RootComponentScan(warning = "操作后扫描失败，请刷新；不使用旧状态") }
-                    }
-                    mutableComponentBusy.value = false
-                }
-            }
-        }
-    }
+    fun dismissComponentRootNotice() = rootComponents.dismissRootNotice()
+    fun refreshComponents() = rootComponents.refresh()
+    fun changeComponent(target: RootComponent, enable: Boolean) = rootComponents.change(target, enable)
+    fun changeComponents(targets: List<RootComponent>, enable: Boolean) = rootComponents.change(targets, enable)
+    fun invertComponents(targets: List<RootComponent>) = rootComponents.invert(targets)
 
     private val mutableUpdating = MutableStateFlow(false)
     val updating: StateFlow<Boolean> = mutableUpdating
@@ -373,8 +272,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                         runtime = app.runtime.value,
                         syncStatus = app.syncStatus.value
                     ),
-                    mutableComponentScan.value,
-                    rootCatalog.lastOperation
+                    rootComponents.scan.value,
+                    rootComponents.lastOperation
                 )
                 val ready = requireNotNull(report)
                 withContext(Dispatchers.IO) {
@@ -802,6 +701,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                             override fun onScopeRequestApproved(approved: List<String>) {
                                 if (continuation.isActive) continuation.resume(approved)
                             }
+
                             override fun onScopeRequestFailed(message: String) {
                                 if (continuation.isActive) {
                                     continuation.resumeWithException(IllegalStateException(message))

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
@@ -114,6 +114,15 @@ data class AppGroup(
     val components: List<ComponentCandidate>
 )
 
+private fun appSelectionRank(group: AppGroup, selected: Set<ComponentRule>): Int {
+    val selectedCount = group.components.count { it.rule in selected }
+    return when {
+        group.components.isNotEmpty() && selectedCount == group.components.size -> 0
+        selectedCount > 0 -> 1
+        else -> 2
+    }
+}
+
 fun groupCandidates(
     candidates: List<ComponentCandidate>,
     selected: Set<ComponentRule>,
@@ -137,7 +146,11 @@ fun groupCandidates(
         all.first().appIcon,
         matching
     )
-}.sortedBy { it.appLabel.lowercase() }
+}.sortedWith(
+    compareBy<AppGroup> { appSelectionRank(it, selected) }
+        .thenBy { it.appLabel.lowercase() }
+        .thenBy { it.packageName }
+)
 
 fun retainConfiguredCandidates(
     items: List<ComponentCandidate>,

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
@@ -98,7 +98,10 @@ data class MainState(
     val diagnosticMode: Boolean = false,
     val priorities: PriorityConfig = PriorityConfig(),
     val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
+    /** Effective OPEN config shown by UI after generic inheritance is applied. */
     val openTypes: OpenTypeConfig = OpenTypeConfig(),
+    /** Raw per-type config, used to distinguish inherited values from explicit overrides. */
+    val openTypesExplicit: OpenTypeConfig = OpenTypeConfig(),
     val tiles: TileConfig = TileConfig(),
     val hiddenFromApps: Set<String> = emptySet(),
     val groups: List<AppGroup> = emptyList(),
@@ -115,7 +118,7 @@ data class AppGroup(
 )
 
 fun groupCandidates(candidates: List<ComponentCandidate>, selected: Set<ComponentRule>, filter: IntentKind?, query: String, uiFilter: UiFilter): List<AppGroup> =
-    candidates.groupBy { it.rule.packageName }.mapNotNull { (pkg, all) ->
+    candidates.groupBy { it.rule.packageName }.mapNotNull { (_, all) ->
         val matching = all.filter {
             val isSelected = it.rule in selected
             val matchesUiFilter = when (uiFilter) {
@@ -126,7 +129,7 @@ fun groupCandidates(candidates: List<ComponentCandidate>, selected: Set<Componen
             catalogVisible(it, isSelected, uiFilter) && matchesUiFilter && (filter == null || it.rule.kind == filter) &&
                 it.matchesQuery(query)
         }.sortedBy { it.rule.kind.ordinal }
-        if (matching.isEmpty()) null else AppGroup(pkg, all.first().appLabel, all.first().appIcon,
+        if (matching.isEmpty()) null else AppGroup(all.first().rule.packageName, all.first().appLabel, all.first().appIcon,
             matching)
     }.sortedBy { it.appLabel.lowercase() }
 
@@ -255,12 +258,39 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         if (mutableCheckingFile.value) return
         mutableCheckingFile.value = true
         viewModelScope.launch {
-            mutableFileCheckStatus.value = "正在检查实际文件的候选，不会打开文件…"
+            mutableFileCheckStatus.value = "正在检查实际文件的候选和规则效果，不会打开文件…"
             try {
                 check(app.synchronize()) { app.runtime.value.message }
+                val mime = app.contentResolver.getType(uri)
                 val found = app.catalog.inspectFile(uri)
+                val config = app.rules.remoteSnapshot()
+                val preview = com.yagay.ListCleaner.domain.previewOpenEffect(
+                    candidates = found,
+                    genericSelected = config.rules,
+                    mode = config.mode,
+                    priorities = config.priorities,
+                    openTypes = config.openTypes,
+                    mimeType = mime,
+                    scheme = uri.scheme,
+                    fileNameOrPath = uri.lastPathSegment ?: uri.path
+                )
                 check(app.synchronize()) { app.runtime.value.message }
-                mutableFileCheckStatus.value = "查询返回 ${found.size} 个组件，其中 ${found.count { it.isCatalogCandidate }} 个符合目录管理条件。实际启动还取决于来源应用权限；明细见诊断包，不改变规则列表。"
+                mutableFileCheckStatus.value = buildString {
+                    append("识别类型：${preview.preset?.title ?: "通用打开方式"} · MIME=${mime ?: "未知"}\n")
+                    append("原始候选 ${preview.rawCount} 个 → 预计最终 ${preview.finalCount} 个")
+                    if (preview.restoredEmpty) append("（触发空列表保护，恢复系统原结果）")
+                    append("。此预览不模拟来源应用自身的私有菜单或同 UID 保护。")
+                    val details = preview.items.take(12)
+                    if (details.isNotEmpty()) append("\n")
+                    details.forEachIndexed { index, item ->
+                        if (index > 0) append("\n")
+                        append(if (item.included) "✓ " else "✕ ")
+                        append(item.candidate.appLabel)
+                        item.rank?.let { append(" · 优先第 $it 位") }
+                        item.selectedBy?.let { append(" · 规则来源：$it") }
+                    }
+                    if (preview.items.size > details.size) append("\n…另有 ${preview.items.size - details.size} 项，完整候选见诊断包")
+                }
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (failure: Exception) {
@@ -270,6 +300,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             }
         }
     }
+
     private val loading = MutableStateFlow(true)
     private val error = MutableStateFlow<String?>(null)
     private val filter = MutableStateFlow<IntentKind?>(null)
@@ -301,7 +332,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 report = DiagnosticCollector.collect(app, state.value.copy(
                     module = freshStatus, selected = config.rules, displayMode = config.mode,
                     priorities = config.priorities, diagnosticMode = config.diagnostic, tiles = config.tiles,
-                    openTypes = config.openTypes, defaultOpen = config.defaultOpen,
+                    openTypes = config.openTypes, openTypesExplicit = config.openTypes, defaultOpen = config.defaultOpen,
                     runtime = app.runtime.value,
                     syncStatus = app.syncStatus.value
                 ), mutableComponentScan.value, rootCatalog.lastOperation)
@@ -373,6 +404,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             hiddenFromApps = values[12] as Set<String>,
             defaultOpen = values[13] as DefaultOpenConfig,
             openTypes = effectiveOpenTypes,
+            openTypesExplicit = rawOpenTypes,
             uiFilter = content.uiFilter
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), MainState())
@@ -531,9 +563,6 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private fun genericOpenSelected(): Set<ComponentRule> =
         app.rules.rules.value.filterTo(linkedSetOf()) { it.kind == IntentKind.OPEN }
 
-    private fun explicitOpenTypeRules(preset: OpenPreset): Set<ComponentRule> =
-        app.rules.openTypes.value.rules[preset].orEmpty().mapNotNullTo(linkedSetOf(), ComponentRule::fromId)
-
     private fun openTypePriorityBase(preset: OpenPreset): List<String> {
         val explicit = app.rules.openTypes.value.priorities[preset].orEmpty()
         return if (explicit.isNotEmpty()) explicit else app.rules.priorities.value.apps[IntentKind.OPEN].orEmpty()
@@ -676,6 +705,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         if (current != expected) return
         val updated = com.yagay.ListCleaner.domain.moveVisiblePriorityTo(current, visible, packageName, target)
         if (updated != current) app.rules.setOpenTypePriority(preset, updated)
+    }
+
+    fun resetOpenTypePriority(preset: OpenPreset) {
+        if (canEdit()) app.rules.setOpenTypePriority(preset, emptyList())
     }
 
     fun requestScope() {

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
@@ -6,34 +6,32 @@ import android.net.Uri
 import java.io.File
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Dashboard
+import androidx.compose.material.icons.rounded.GridView
 import androidx.compose.material.icons.rounded.List
 import androidx.compose.material.icons.rounded.Sort
-import androidx.compose.material.icons.rounded.GridView
-import com.yagay.ListCleaner.domain.TileConfig
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.yagay.ListCleaner.BuildConfig
+import com.yagay.ListCleaner.ListCleanerApp
+import com.yagay.ListCleaner.RuntimeStatus
+import com.yagay.ListCleaner.data.ComponentRootCommand
+import com.yagay.ListCleaner.data.ResolverScopeDetector
 import com.yagay.ListCleaner.data.RootComponent
 import com.yagay.ListCleaner.data.RootComponentCatalog
 import com.yagay.ListCleaner.data.RootComponentScan
-import com.yagay.ListCleaner.data.ComponentRootCommand
-import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.viewModelScope
-import com.yagay.ListCleaner.ListCleanerApp
-import com.yagay.ListCleaner.RuntimeStatus
-import com.yagay.ListCleaner.BuildConfig
-import com.yagay.ListCleaner.domain.RuntimeProtocol
-import io.github.libxposed.service.HookedTarget
-import io.github.libxposed.service.HotReloadResult
 import com.yagay.ListCleaner.data.RuleRepository
-import com.yagay.ListCleaner.data.ResolverScopeDetector
 import com.yagay.ListCleaner.data.ScopeDetection
 import com.yagay.ListCleaner.domain.ComponentCandidate
 import com.yagay.ListCleaner.domain.ComponentRule
-import com.yagay.ListCleaner.domain.IntentKind
+import com.yagay.ListCleaner.domain.CustomOpenDefinition
 import com.yagay.ListCleaner.domain.DisplayMode
-import com.yagay.ListCleaner.domain.PriorityConfig
-import com.yagay.ListCleaner.domain.DefaultOpenConfig
+import com.yagay.ListCleaner.domain.IntentKind
 import com.yagay.ListCleaner.domain.OpenPreset
 import com.yagay.ListCleaner.domain.OpenTypeConfig
-import com.yagay.ListCleaner.domain.CustomOpenDefinition
+import com.yagay.ListCleaner.domain.PriorityConfig
+import com.yagay.ListCleaner.domain.RuntimeProtocol
+import io.github.libxposed.service.HookedTarget
+import io.github.libxposed.service.HotReloadResult
 import io.github.libxposed.service.XposedService
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -45,8 +43,8 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -67,9 +65,12 @@ data class ModuleStatus(
     val missingScope: Set<String> get() = detection.recommended - grantedScope
     val extraScope: Set<String> get() = grantedScope - detection.hosts.map { it.packageName }.toSet()
     val resolverLoaded: Boolean get() = runningTargets.any { target ->
-        RuntimeProtocol.current(target.state, target.version, BuildConfig.VERSION_CODE.toLong()) && detection.hosts.any { it.processName == target.processName }
+        RuntimeProtocol.current(target.state, target.version, BuildConfig.VERSION_CODE.toLong()) &&
+            detection.hosts.any { it.processName == target.processName }
     }
-    val outdated: Boolean get() = runningTargets.any { !RuntimeProtocol.current(it.state, it.version, BuildConfig.VERSION_CODE.toLong()) }
+    val outdated: Boolean get() = runningTargets.any {
+        !RuntimeProtocol.current(it.state, it.version, BuildConfig.VERSION_CODE.toLong())
+    }
 }
 
 enum class Destination(val label: String, val icon: androidx.compose.ui.graphics.vector.ImageVector) {
@@ -98,10 +99,10 @@ data class MainState(
     val uiFilter: UiFilter = UiFilter.ALL,
     val diagnosticMode: Boolean = false,
     val priorities: PriorityConfig = PriorityConfig(),
-    val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
+    /** Effective per-type config after generic OPEN inheritance is projected for display. */
     val openTypes: OpenTypeConfig = OpenTypeConfig(),
+    /** Raw persisted per-type config used to distinguish inherited values from explicit values. */
     val openTypesExplicit: OpenTypeConfig = OpenTypeConfig(),
-    val tiles: TileConfig = TileConfig(),
     val hiddenFromApps: Set<String> = emptySet(),
     val groups: List<AppGroup> = emptyList(),
     val destination: Destination = Destination.RULES,
@@ -116,32 +117,52 @@ data class AppGroup(
     val components: List<ComponentCandidate>
 )
 
-fun groupCandidates(candidates: List<ComponentCandidate>, selected: Set<ComponentRule>, filter: IntentKind?, query: String, uiFilter: UiFilter): List<AppGroup> =
-    candidates.groupBy { it.rule.packageName }.mapNotNull { (_, all) ->
-        val matching = all.filter {
-            val isSelected = it.rule in selected
-            val matchesUiFilter = when (uiFilter) {
-                UiFilter.ALL -> true
-                UiFilter.HIDE_SELECTED -> !isSelected
-                UiFilter.SHOW_SELECTED -> isSelected
-            }
-            catalogVisible(it, isSelected, uiFilter) && matchesUiFilter && (filter == null || it.rule.kind == filter) && it.matchesQuery(query)
-        }.sortedBy { it.rule.kind.ordinal }
-        if (matching.isEmpty()) null else AppGroup(all.first().rule.packageName, all.first().appLabel, all.first().appIcon, matching)
-    }.sortedBy { it.appLabel.lowercase() }
+fun groupCandidates(
+    candidates: List<ComponentCandidate>,
+    selected: Set<ComponentRule>,
+    filter: IntentKind?,
+    query: String,
+    uiFilter: UiFilter
+): List<AppGroup> = candidates.groupBy { it.rule.packageName }.mapNotNull { (_, all) ->
+    val matching = all.filter {
+        val isSelected = it.rule in selected
+        val matchesUiFilter = when (uiFilter) {
+            UiFilter.ALL -> true
+            UiFilter.HIDE_SELECTED -> !isSelected
+            UiFilter.SHOW_SELECTED -> isSelected
+        }
+        catalogVisible(it, isSelected, uiFilter) && matchesUiFilter &&
+            (filter == null || it.rule.kind == filter) && it.matchesQuery(query)
+    }.sortedBy { it.rule.kind.ordinal }
+    if (matching.isEmpty()) null else AppGroup(
+        all.first().rule.packageName,
+        all.first().appLabel,
+        all.first().appIcon,
+        matching
+    )
+}.sortedBy { it.appLabel.lowercase() }
 
-fun retainConfiguredCandidates(items: List<ComponentCandidate>, selected: Set<ComponentRule>): List<ComponentCandidate> {
+fun retainConfiguredCandidates(
+    items: List<ComponentCandidate>,
+    selected: Set<ComponentRule>
+): List<ComponentCandidate> {
     val kept = items.filter { !it.unavailable || it.rule in selected }
     val ids = kept.map { it.rule.id }.toSet()
     return kept + selected.filter { it.id !in ids }.map { rule ->
-        ComponentCandidate(rule, rule.packageName, rule.className.substringAfterLast('.'),
-            evidence = listOf("已配置，但本次未扫描到；不代表已卸载"), unavailable = true)
+        ComponentCandidate(
+            rule,
+            rule.packageName,
+            rule.className.substringAfterLast('.'),
+            evidence = listOf("已配置，但本次未扫描到；不代表已卸载"),
+            unavailable = true
+        )
     }
 }
 
 class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val app = application as ListCleanerApp
     private val rootCatalog = RootComponentCatalog(app)
+
     private val mutableComponentScan = MutableStateFlow(RootComponentScan())
     val componentScan: StateFlow<RootComponentScan> = mutableComponentScan
     private val mutableComponentBusy = MutableStateFlow(false)
@@ -157,10 +178,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         if (mutableComponentBusy.value) return
         mutableComponentBusy.value = true
         viewModelScope.launch {
-            try { mutableComponentScan.value = withContext(Dispatchers.IO) { rootCatalog.scan() } }
-            catch (cancelled: CancellationException) { throw cancelled }
-            catch (failure: Exception) { mutableComponentMessage.value = failure.message ?: "扫描失败" }
-            finally { mutableComponentBusy.value = false }
+            try {
+                mutableComponentScan.value = withContext(Dispatchers.IO) { rootCatalog.scan() }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Exception) {
+                mutableComponentMessage.value = failure.message ?: "扫描失败"
+            } finally {
+                mutableComponentBusy.value = false
+            }
         }
     }
 
@@ -168,8 +194,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun changeComponents(visibleTargets: List<RootComponent>, enable: Boolean) {
         if (mutableComponentBusy.value) return
-        val targets = visibleTargets.filter { it.blocked == null && it.enabled != null && it.enabled != enable }
-            .distinctBy { "${it.user}|${it.component.flattenToString()}" }
+        val targets = visibleTargets.filter {
+            it.blocked == null && it.enabled != null && it.enabled != enable
+        }.distinctBy { "${it.user}|${it.component.flattenToString()}" }
         if (targets.isEmpty()) return
         mutableComponentRootNotice.value = null
         mutableComponentBusy.value = true
@@ -187,15 +214,19 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                         result = rootCatalog.change(target, enable)
                         completed++
                     }
-                    mutableComponentMessage.value = if (targets.size == 1) result else "已核验：${completed} 个组件已${if (enable) "启用" else "禁用"}；请重新打开目标选择器"
+                    mutableComponentMessage.value = if (targets.size == 1) result
+                    else "已核验：$completed 个组件已${if (enable) "启用" else "禁用"}；请重新打开目标选择器"
                 } catch (failure: ComponentRootCommand.RootAccessException) {
                     mutableComponentMessage.value = failure.message
                     mutableComponentRootNotice.value = failure.message
                 } catch (failure: Exception) {
                     mutableComponentMessage.value = "已完成 $completed/${targets.size}，操作已停止：${failure.message ?: "操作失败"}。失败项请核对系统状态；剩余项未执行，已完成项不回滚。"
                 } finally {
-                    if (operationStarted) runCatching { rootCatalog.scan() }.onSuccess { mutableComponentScan.value = it }
-                        .onFailure { mutableComponentScan.value = RootComponentScan(warning = "操作后扫描失败，请刷新；不使用旧状态") }
+                    if (operationStarted) {
+                        runCatching { rootCatalog.scan() }
+                            .onSuccess { mutableComponentScan.value = it }
+                            .onFailure { mutableComponentScan.value = RootComponentScan(warning = "操作后扫描失败，请刷新；不使用旧状态") }
+                    }
                     mutableComponentBusy.value = false
                 }
             }
@@ -204,8 +235,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun invertComponents(visibleTargets: List<RootComponent>) {
         if (mutableComponentBusy.value) return
-        val targets = visibleTargets.filter { it.blocked == null && it.enabled != null }
-            .distinctBy { "${it.user}|${it.component.flattenToString()}" }
+        val targets = visibleTargets.filter {
+            it.blocked == null && it.enabled != null
+        }.distinctBy { "${it.user}|${it.component.flattenToString()}" }
         if (targets.isEmpty()) return
         mutableComponentRootNotice.value = null
         mutableComponentBusy.value = true
@@ -218,9 +250,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     rootCatalog.requireRoot()
                     for (target in targets) {
                         operationStarted = true
-                        val enable = target.enabled == false
                         mutableComponentMessage.value = "正在反选 ${completed + 1}/${targets.size}：${target.label}"
-                        rootCatalog.change(target, enable)
+                        rootCatalog.change(target, target.enabled == false)
                         completed++
                     }
                     mutableComponentMessage.value = "已核验：$completed 个组件已反选；请重新打开目标选择器"
@@ -230,8 +261,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 } catch (failure: Exception) {
                     mutableComponentMessage.value = "已完成 $completed/${targets.size}，反选已停止：${failure.message ?: "操作失败"}。已完成项不回滚。"
                 } finally {
-                    if (operationStarted) runCatching { rootCatalog.scan() }.onSuccess { mutableComponentScan.value = it }
-                        .onFailure { mutableComponentScan.value = RootComponentScan(warning = "操作后扫描失败，请刷新；不使用旧状态") }
+                    if (operationStarted) {
+                        runCatching { rootCatalog.scan() }
+                            .onSuccess { mutableComponentScan.value = it }
+                            .onFailure { mutableComponentScan.value = RootComponentScan(warning = "操作后扫描失败，请刷新；不使用旧状态") }
+                    }
                     mutableComponentBusy.value = false
                 }
             }
@@ -242,6 +276,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     val updating: StateFlow<Boolean> = mutableUpdating
     private val mutableUpdateMessage = MutableStateFlow<String?>(null)
     val updateMessage: StateFlow<String?> = mutableUpdateMessage
+
     private val candidates = MutableStateFlow<List<ComponentCandidate>>(emptyList())
     private val mutableFileCheckStatus = MutableStateFlow<String?>(null)
     val fileCheckStatus: StateFlow<String?> = mutableFileCheckStatus
@@ -259,8 +294,14 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val found = app.catalog.inspectFile(uri)
                 val config = app.rules.remoteSnapshot()
                 val preview = com.yagay.ListCleaner.domain.previewOpenEffect(
-                    found, config.rules, config.mode, config.priorities, config.openTypes,
-                    mime, uri.scheme, uri.lastPathSegment ?: uri.path
+                    found,
+                    config.rules,
+                    config.mode,
+                    config.priorities,
+                    config.openTypes,
+                    mime,
+                    uri.scheme,
+                    uri.lastPathSegment ?: uri.path
                 )
                 check(app.synchronize()) { app.runtime.value.message }
                 mutableFileCheckStatus.value = buildString {
@@ -269,19 +310,25 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     if (preview.restoredEmpty) append("（触发空列表保护，恢复系统原结果）")
                     append("。此预览不模拟来源应用自身的私有菜单或同 UID 保护。")
                     val details = preview.items.take(12)
-                    if (details.isNotEmpty()) append("\n")
+                    if (details.isNotEmpty()) append('\n')
                     details.forEachIndexed { index, item ->
-                        if (index > 0) append("\n")
+                        if (index > 0) append('\n')
                         append(if (item.included) "✓ " else "✕ ")
                         append(item.candidate.appLabel)
                         item.rank?.let { append(" · 优先第 $it 位") }
                         item.selectedBy?.let { append(" · 规则来源：$it") }
                     }
-                    if (preview.items.size > details.size) append("\n…另有 ${preview.items.size - details.size} 项，完整候选见诊断包")
+                    if (preview.items.size > details.size) {
+                        append("\n…另有 ${preview.items.size - details.size} 项，完整候选见诊断包")
+                    }
                 }
-            } catch (cancelled: CancellationException) { throw cancelled }
-            catch (failure: Exception) { mutableFileCheckStatus.value = failure.message ?: "文件检查失败" }
-            finally { mutableCheckingFile.value = false }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Exception) {
+                mutableFileCheckStatus.value = failure.message ?: "文件检查失败"
+            } finally {
+                mutableCheckingFile.value = false
+            }
         }
     }
 
@@ -298,6 +345,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private var statusGeneration = 0L
     private var scopeRequestInFlight = false
     private val scopeDetector = ResolverScopeDetector(application)
+
     private val mutableCollectingDiagnostics = MutableStateFlow(false)
     val collectingDiagnostics: StateFlow<Boolean> = mutableCollectingDiagnostics
     private val mutableExportMessage = MutableStateFlow<String?>(null)
@@ -311,75 +359,119 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             var report: File? = null
             try {
-                val freshStatus = moduleStatus.value
                 val config = app.rules.remoteSnapshot()
-                report = DiagnosticCollector.collect(app, state.value.copy(
-                    module = freshStatus, selected = config.rules, displayMode = config.mode,
-                    priorities = config.priorities, diagnosticMode = config.diagnostic, tiles = config.tiles,
-                    openTypes = config.openTypes, openTypesExplicit = config.openTypes, defaultOpen = config.defaultOpen,
-                    runtime = app.runtime.value, syncStatus = app.syncStatus.value
-                ), mutableComponentScan.value, rootCatalog.lastOperation)
+                report = DiagnosticCollector.collect(
+                    app,
+                    state.value.copy(
+                        module = moduleStatus.value,
+                        selected = config.rules,
+                        displayMode = config.mode,
+                        priorities = config.priorities,
+                        diagnosticMode = config.diagnostic,
+                        openTypes = config.openTypes,
+                        openTypesExplicit = config.openTypes,
+                        runtime = app.runtime.value,
+                        syncStatus = app.syncStatus.value
+                    ),
+                    mutableComponentScan.value,
+                    rootCatalog.lastOperation
+                )
                 val ready = requireNotNull(report)
                 withContext(Dispatchers.IO) {
                     val output = app.contentResolver.openOutputStream(uri, "wt") ?: error("无法创建诊断包")
                     output.use { destination -> ready.inputStream().use { it.copyTo(destination) } }
                 }
                 mutableExportMessage.value = "诊断包已导出"
-            } catch (cancelled: CancellationException) { throw cancelled }
-            catch (failure: Exception) { mutableExportMessage.value = "导出失败：${failure.message}；目标文件可能不完整，请重新导出" }
-            finally { report?.delete(); mutableCollectingDiagnostics.value = false }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Exception) {
+                mutableExportMessage.value = "导出失败：${failure.message}；目标文件可能不完整，请重新导出"
+            } finally {
+                report?.delete()
+                mutableCollectingDiagnostics.value = false
+            }
         }
     }
 
-    private data class ListContent(val candidates: List<ComponentCandidate>, val filter: IntentKind?, val query: String, val groups: List<AppGroup>,
-        val selected: Set<ComponentRule> = emptySet(), val uiFilter: UiFilter = UiFilter.ALL)
+    private data class ListContent(
+        val candidates: List<ComponentCandidate>,
+        val filter: IntentKind?,
+        val query: String,
+        val groups: List<AppGroup>,
+        val selected: Set<ComponentRule> = emptySet(),
+        val uiFilter: UiFilter = UiFilter.ALL
+    )
 
-    private val grouped = combine(candidates, app.rules.rules, filter, query, uiFilter) { scanned, selected, kind, text, ui ->
+    private val grouped = combine(candidates, app.rules.rules, filter, query, uiFilter) {
+        scanned, selected, kind, text, ui ->
         val items = retainConfiguredCandidates(scanned, selected)
         ListContent(items, kind, text, groupCandidates(items, selected, kind, text, ui), selected, ui)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListContent(emptyList(), null, "", emptyList()))
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        ListContent(emptyList(), null, "", emptyList())
+    )
 
     val state: StateFlow<MainState> = combine(
-        moduleStatus, loading, error, grouped, app.runtime, app.rules.displayMode, app.rules.priorities, app.rules.diagnosticMode, app.syncStatus, destination, expandedAppKey, app.rules.tiles, app.rules.hiddenFromApps, app.rules.defaultOpen, app.rules.openTypes
+        moduleStatus,
+        loading,
+        error,
+        grouped,
+        app.runtime,
+        app.rules.displayMode,
+        app.rules.priorities,
+        app.rules.diagnosticMode,
+        app.syncStatus,
+        destination,
+        expandedAppKey,
+        app.rules.hiddenFromApps,
+        app.rules.openTypes
     ) { values ->
         @Suppress("UNCHECKED_CAST")
         val content = values[3] as ListContent
         val priorityConfig = values[6] as PriorityConfig
-        val rawOpenTypes = values[14] as OpenTypeConfig
-        val genericOpenIds = content.selected.asSequence().filter { it.kind == IntentKind.OPEN }.map { it.id }.toSet()
-        val genericOpenPriority = priorityConfig.apps[IntentKind.OPEN].orEmpty()
-        val typedPresets = rawOpenTypes.configuredPresets()
-        val effectiveRules = typedPresets.mapNotNull { preset ->
-            val ids = genericOpenIds + rawOpenTypes.rules[preset].orEmpty()
-            if (ids.isEmpty()) null else preset to ids
-        }.toMap()
-        val effectivePriorities = typedPresets.mapNotNull { preset ->
-            val explicit = rawOpenTypes.priorities[preset].orEmpty()
-            val packages = if (explicit.isNotEmpty()) explicit else genericOpenPriority
-            if (packages.isEmpty()) null else preset to packages
-        }.toMap()
-        val effectiveOpenTypes = rawOpenTypes.copy(rules = effectiveRules, priorities = effectivePriorities)
+        val rawOpenTypes = values[12] as OpenTypeConfig
         MainState(
-            module = values[0] as ModuleStatus, loading = values[1] as Boolean, error = values[2] as String?,
-            candidates = content.candidates, selected = content.selected, runtime = values[4] as RuntimeStatus,
-            displayMode = values[5] as DisplayMode, filter = content.filter, query = content.query,
-            priorities = priorityConfig, groups = content.groups, diagnosticMode = values[7] as Boolean,
-            syncStatus = values[8] as String, destination = values[9] as Destination,
-            expandedAppKey = values[10] as String?, tiles = values[11] as TileConfig,
-            hiddenFromApps = values[12] as Set<String>, defaultOpen = values[13] as DefaultOpenConfig,
-            openTypes = effectiveOpenTypes, openTypesExplicit = rawOpenTypes, uiFilter = content.uiFilter
+            module = values[0] as ModuleStatus,
+            loading = values[1] as Boolean,
+            error = values[2] as String?,
+            candidates = content.candidates,
+            selected = content.selected,
+            runtime = values[4] as RuntimeStatus,
+            displayMode = values[5] as DisplayMode,
+            filter = content.filter,
+            query = content.query,
+            priorities = priorityConfig,
+            groups = content.groups,
+            diagnosticMode = values[7] as Boolean,
+            syncStatus = values[8] as String,
+            destination = values[9] as Destination,
+            expandedAppKey = values[10] as String?,
+            hiddenFromApps = values[11] as Set<String>,
+            openTypes = effectiveOpenTypes(rawOpenTypes, content.selected, priorityConfig),
+            openTypesExplicit = rawOpenTypes,
+            uiFilter = content.uiFilter
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), MainState())
 
     init {
         viewModelScope.launch {
-            app.service.collectLatest { readModuleStatus(it); refresh() }
+            app.service.collectLatest {
+                readModuleStatus(it)
+                refresh()
+            }
         }
     }
 
-    fun setDiagnosticMode(enabled: Boolean) { app.rules.setDiagnosticMode(enabled); refreshModuleStatus() }
-    fun setDefaultOpen(preset: OpenPreset, ruleId: String?) { if (canEdit()) app.rules.setDefaultOpen(preset, ruleId) }
-    fun setHiddenFromApps(packages: Set<String>) { app.rules.setHiddenFromApps(packages); viewModelScope.launch { app.synchronize() } }
+    fun setDiagnosticMode(enabled: Boolean) {
+        app.rules.setDiagnosticMode(enabled)
+        refreshModuleStatus()
+    }
+
+    fun setHiddenFromApps(packages: Set<String>) {
+        app.rules.setHiddenFromApps(packages)
+        viewModelScope.launch { app.synchronize() }
+    }
 
     fun setCustomOpenDefinition(preset: OpenPreset, definition: CustomOpenDefinition?) {
         if (!canEdit()) return
@@ -394,25 +486,42 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             loading.value = true
             error.value = null
             try {
-                val configured = app.rules.rules.value + app.rules.openTypes.value.rules.values.flatten().mapNotNull(ComponentRule::fromId)
+                val configured = app.rules.rules.value +
+                    app.rules.openTypes.value.rules.values.flatten().mapNotNull(ComponentRule::fromId)
                 candidates.value = app.catalog.completeConfigured(candidates.value, configured)
                 check(app.synchronize()) { app.runtime.value.message }
                 val result = app.catalog.scan(app.rules.openTypes.value.customDefinitions)
                 check(app.synchronize()) { app.runtime.value.message }
                 if (generation == refreshGeneration) {
-                    val updatedConfigured = app.rules.rules.value + app.rules.openTypes.value.rules.values.flatten().mapNotNull(ComponentRule::fromId)
+                    val updatedConfigured = app.rules.rules.value +
+                        app.rules.openTypes.value.rules.values.flatten().mapNotNull(ComponentRule::fromId)
                     candidates.value = app.catalog.completeConfigured(result, updatedConfigured)
                     error.value = app.catalog.scanWarning
                 }
-            } catch (cancelled: CancellationException) { throw cancelled }
-            catch (failure: Throwable) { if (generation == refreshGeneration) error.value = failure.message ?: "扫描失败" }
-            finally { if (generation == refreshGeneration) loading.value = false }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Throwable) {
+                if (generation == refreshGeneration) error.value = failure.message ?: "扫描失败"
+            } finally {
+                if (generation == refreshGeneration) loading.value = false
+            }
         }
         refreshModuleStatus()
     }
 
-    fun refreshModuleStatus() { viewModelScope.launch { readModuleStatus(app.service.value); app.synchronize() } }
-    fun resolveRecovery(restore: Boolean) { viewModelScope.launch { app.resolveRecovery(restore); refresh() } }
+    fun refreshModuleStatus() {
+        viewModelScope.launch {
+            readModuleStatus(app.service.value)
+            app.synchronize()
+        }
+    }
+
+    fun resolveRecovery(restore: Boolean) {
+        viewModelScope.launch {
+            app.resolveRecovery(restore)
+            refresh()
+        }
+    }
 
     fun applyModuleUpdate() {
         if (mutableUpdating.value) return
@@ -422,16 +531,26 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             try {
                 val bound = app.service.value ?: error("未连接 LSPosed")
                 val targets = withContext(Dispatchers.IO) { bound.runningTargets }
-                val pending = targets.filter { !RuntimeProtocol.current(it.state.name, it.loadedVersionCode, BuildConfig.VERSION_CODE.toLong()) }
+                val pending = targets.filter {
+                    !RuntimeProtocol.current(it.state.name, it.loadedVersionCode, BuildConfig.VERSION_CODE.toLong())
+                }
                 val messages = mutableListOf<String>()
                 for (target in pending) {
                     try {
-                        if (target.state == HookedTarget.State.RELOADING) { messages += "${target.processName}：框架正在重载，请稍后重新检测"; continue }
-                        if (target.loadedVersionCode < 19) { messages += "${target.processName}：旧版本 ${target.loadedVersionCode} 不支持本模块热重载，请完整重启手机"; continue }
+                        if (target.state == HookedTarget.State.RELOADING) {
+                            messages += "${target.processName}：框架正在重载，请稍后重新检测"
+                            continue
+                        }
+                        if (target.loadedVersionCode < 19) {
+                            messages += "${target.processName}：旧版本 ${target.loadedVersionCode} 不支持本模块热重载，请完整重启手机"
+                            continue
+                        }
                         val result = withTimeoutOrNull(15_000) {
                             withContext(Dispatchers.IO) {
                                 suspendCancellableCoroutine<HotReloadResult> { continuation ->
-                                    bound.hotReloadModule(target, null) { _, reply -> if (continuation.isActive) continuation.resume(reply) }
+                                    bound.hotReloadModule(target, null) { _, reply ->
+                                        if (continuation.isActive) continuation.resume(reply)
+                                    }
                                 }
                             }
                         }
@@ -443,14 +562,23 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                             HotReloadResult.Status.IN_PROGRESS -> "框架正在重载，请稍后重新检测"
                             null -> "等待超时，不代表已取消；请重新检测，勿重复请求"
                         }
-                    } catch (cancelled: CancellationException) { throw cancelled }
-                    catch (failure: Exception) { messages += "${target.processName}：更新请求失败（${failure.javaClass.simpleName}）；继续检查其他目标" }
+                    } catch (cancelled: CancellationException) {
+                        throw cancelled
+                    } catch (failure: Exception) {
+                        messages += "${target.processName}：更新请求失败（${failure.javaClass.simpleName}）；继续检查其他目标"
+                    }
                 }
-                mutableUpdateMessage.value = if (messages.isEmpty()) "没有需要热更新的运行目标；正在核实配置" else messages.joinToString("\n")
+                mutableUpdateMessage.value = if (messages.isEmpty()) {
+                    "没有需要热更新的运行目标；正在核实配置"
+                } else messages.joinToString("\n")
                 refresh()
-            } catch (cancelled: CancellationException) { throw cancelled }
-            catch (failure: Exception) { mutableUpdateMessage.value = "更新检查失败：${failure.message}；未重启任何系统进程" }
-            finally { mutableUpdating.value = false }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Exception) {
+                mutableUpdateMessage.value = "更新检查失败：${failure.message}；未重启任何系统进程"
+            } finally {
+                mutableUpdating.value = false
+            }
         }
     }
 
@@ -461,16 +589,27 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             var result = ModuleStatus(connected = service != null, detection = detection)
             if (service != null) {
                 try {
-                    result = result.copy(apiVersion = service.apiVersion, grantedScope = service.scope.toSet(), scopeKnown = true)
-                    result = if ((result.apiVersion ?: 0) >= 102) result.copy(runningTargets = service.runningTargets.map {
-                        RunningTargetStatus(it.processName, it.state.name, it.loadedVersionCode)
-                    }) else result.copy(error = "当前框架不支持运行目标检测")
-                } catch (cancelled: CancellationException) { throw cancelled }
-                catch (failure: Exception) { result = result.copy(error = failure.message ?: "无法读取 LSPosed 模块状态") }
+                    result = result.copy(
+                        apiVersion = service.apiVersion,
+                        grantedScope = service.scope.toSet(),
+                        scopeKnown = true
+                    )
+                    result = if ((result.apiVersion ?: 0) >= 102) {
+                        result.copy(runningTargets = service.runningTargets.map {
+                            RunningTargetStatus(it.processName, it.state.name, it.loadedVersionCode)
+                        })
+                    } else result.copy(error = "当前框架不支持运行目标检测")
+                } catch (cancelled: CancellationException) {
+                    throw cancelled
+                } catch (failure: Exception) {
+                    result = result.copy(error = failure.message ?: "无法读取 LSPosed 模块状态")
+                }
             }
             result
         }
-        if (generation == statusGeneration && app.service.value === service) moduleStatus.value = status.copy(requesting = scopeRequestInFlight)
+        if (generation == statusGeneration && app.service.value === service) {
+            moduleStatus.value = status.copy(requesting = scopeRequestInFlight)
+        }
         return status
     }
 
@@ -478,32 +617,51 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         if (!it) error.value = "请先完成远程配置恢复或重置，避免覆盖原有规则"
     }
 
-    private fun genericOpenSelected(): Set<ComponentRule> = app.rules.rules.value.filterTo(linkedSetOf()) { it.kind == IntentKind.OPEN }
+    private fun genericOpenSelected(): Set<ComponentRule> =
+        app.rules.rules.value.filterTo(linkedSetOf()) { it.kind == IntentKind.OPEN }
+
     private fun openTypePriorityBase(preset: OpenPreset): List<String> {
         val explicit = app.rules.openTypes.value.priorities[preset].orEmpty()
-        return if (explicit.isNotEmpty()) explicit else app.rules.priorities.value.apps[IntentKind.OPEN].orEmpty()
+        return if (explicit.isNotEmpty()) explicit
+        else app.rules.priorities.value.apps[IntentKind.OPEN].orEmpty()
     }
 
     fun toggle(rule: ComponentRule) { if (canEdit()) app.rules.toggle(rule) }
-    fun setGroupSelected(group: AppGroup, selected: Boolean) { if (canEdit()) app.rules.setSelected(group.components.map { it.rule }, selected) }
-    fun toggleOpenType(preset: OpenPreset, rule: ComponentRule) { if (canEdit() && rule !in genericOpenSelected()) app.rules.toggleOpenType(preset, rule) }
+
+    fun setGroupSelected(group: AppGroup, selected: Boolean) {
+        if (canEdit()) app.rules.setSelected(group.components.map { it.rule }, selected)
+    }
+
+    fun toggleOpenType(preset: OpenPreset, rule: ComponentRule) {
+        if (canEdit() && rule !in genericOpenSelected()) app.rules.toggleOpenType(preset, rule)
+    }
+
     fun setOpenTypeGroupSelected(preset: OpenPreset, group: AppGroup, selected: Boolean) {
         if (!canEdit()) return
         val editable = group.components.map { it.rule }.filterNot { it in genericOpenSelected() }
         if (editable.isNotEmpty()) app.rules.setOpenTypeSelected(preset, editable, selected)
     }
+
     fun selectOpenTypeRules(preset: OpenPreset, rules: Collection<ComponentRule>) {
         if (!canEdit() || rules.isEmpty()) return
         val editable = rules.distinct().filterNot { it in genericOpenSelected() }
         if (editable.isNotEmpty()) app.rules.setOpenTypeSelected(preset, editable, true)
     }
+
     fun invertOpenTypeRules(preset: OpenPreset, rules: Collection<ComponentRule>) {
         if (!canEdit() || rules.isEmpty()) return
         val editable = rules.distinct().filterNot { it in genericOpenSelected() }
         if (editable.isNotEmpty()) app.rules.invertOpenTypeSelected(preset, editable)
     }
-    fun selectRules(rules: Collection<ComponentRule>) { if (canEdit() && rules.isNotEmpty()) app.rules.setSelected(rules.distinct(), true) }
-    fun invertRules(rules: Collection<ComponentRule>) { if (canEdit() && rules.isNotEmpty()) app.rules.invertSelected(rules) }
+
+    fun selectRules(rules: Collection<ComponentRule>) {
+        if (canEdit() && rules.isNotEmpty()) app.rules.setSelected(rules.distinct(), true)
+    }
+
+    fun invertRules(rules: Collection<ComponentRule>) {
+        if (canEdit() && rules.isNotEmpty()) app.rules.invertSelected(rules)
+    }
+
     fun setDisplayMode(value: DisplayMode) { if (canEdit()) app.rules.setDisplayMode(value) }
     fun setFilter(value: IntentKind?) { filter.value = value }
     fun setQuery(value: String) { query.value = value }
@@ -512,7 +670,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun toggleExpandedApp(key: String) { expandedAppKey.value = if (expandedAppKey.value == key) null else key }
     fun exportJson(): String = app.rules.exportJson()
     fun importJson(content: String) = app.rules.importJson(content)
-    fun setComponentTitle(ruleId: String, title: String?) { if (canEdit()) app.rules.setComponentTitle(ruleId, title) }
+    fun setComponentTitle(ruleId: String, title: String?) {
+        if (canEdit()) app.rules.setComponentTitle(ruleId, title)
+    }
 
     fun selectPriorityApps(kind: IntentKind, packageNames: Collection<String>) {
         if (!canEdit()) return
@@ -520,25 +680,46 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val next = (current + packageNames.distinct().filter { it !in current }).take(200)
         if (next != current) app.rules.setPriority(kind, next)
     }
+
     fun invertPriorityApps(kind: IntentKind, packageNames: Collection<String>) {
         if (!canEdit()) return
-        val visible = packageNames.distinct(); if (visible.isEmpty()) return
+        val visible = packageNames.distinct()
+        if (visible.isEmpty()) return
         val current = app.rules.priorities.value.apps[kind].orEmpty()
         val next = (current.filterNot { it in visible.toSet() } + visible.filter { it !in current }).take(200)
         if (next != current) app.rules.setPriority(kind, next)
     }
+
     fun pinApp(kind: IntentKind, packageName: String) {
         if (!canEdit()) return
         val current = app.rules.priorities.value.apps[kind].orEmpty()
         if (packageName !in current && current.size < 200) app.rules.setPriority(kind, current + packageName)
     }
-    fun removePriority(kind: IntentKind, packageName: String) { if (canEdit()) app.rules.setPriority(kind, app.rules.priorities.value.apps[kind].orEmpty() - packageName) }
-    fun movePriority(kind: IntentKind, packageName: String, offset: Int, visible: List<String>) {
-        if (canEdit()) app.rules.setPriority(kind, com.yagay.ListCleaner.domain.moveVisiblePriority(app.rules.priorities.value.apps[kind].orEmpty(), visible, packageName, offset))
+
+    fun removePriority(kind: IntentKind, packageName: String) {
+        if (canEdit()) app.rules.setPriority(kind, app.rules.priorities.value.apps[kind].orEmpty() - packageName)
     }
-    fun movePriorityTo(kind: IntentKind, packageName: String, target: String, visible: List<String>, expected: List<String>) {
+
+    fun movePriority(kind: IntentKind, packageName: String, offset: Int, visible: List<String>) {
         if (!canEdit()) return
-        val current = app.rules.priorities.value.apps[kind].orEmpty(); if (current != expected) return
+        app.rules.setPriority(
+            kind,
+            com.yagay.ListCleaner.domain.moveVisiblePriority(
+                app.rules.priorities.value.apps[kind].orEmpty(), visible, packageName, offset
+            )
+        )
+    }
+
+    fun movePriorityTo(
+        kind: IntentKind,
+        packageName: String,
+        target: String,
+        visible: List<String>,
+        expected: List<String>
+    ) {
+        if (!canEdit()) return
+        val current = app.rules.priorities.value.apps[kind].orEmpty()
+        if (current != expected) return
         val updated = com.yagay.ListCleaner.domain.moveVisiblePriorityTo(current, visible, packageName, target)
         if (updated != current) app.rules.setPriority(kind, updated)
     }
@@ -549,36 +730,53 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val next = (current + packageNames.distinct().filter { it !in current }).take(200)
         if (next != current) app.rules.setOpenTypePriority(preset, next)
     }
+
     fun invertOpenTypePriorityApps(preset: OpenPreset, packageNames: Collection<String>) {
         if (!canEdit()) return
-        val visible = packageNames.distinct(); if (visible.isEmpty()) return
+        val visible = packageNames.distinct()
+        if (visible.isEmpty()) return
         val current = openTypePriorityBase(preset)
         val next = (current.filterNot { it in visible.toSet() } + visible.filter { it !in current }).take(200)
         if (next != current) app.rules.setOpenTypePriority(preset, next)
     }
+
     fun pinOpenTypeApp(preset: OpenPreset, packageName: String) {
         if (!canEdit()) return
         val current = openTypePriorityBase(preset)
         if (packageName !in current && current.size < 200) app.rules.setOpenTypePriority(preset, current + packageName)
     }
+
     fun removeOpenTypePriority(preset: OpenPreset, packageName: String) {
         if (!canEdit()) return
-        val current = openTypePriorityBase(preset); val next = current - packageName
+        val current = openTypePriorityBase(preset)
+        val next = current - packageName
         if (next != current) app.rules.setOpenTypePriority(preset, next)
     }
+
     fun moveOpenTypePriority(preset: OpenPreset, packageName: String, offset: Int, visible: List<String>) {
         if (!canEdit()) return
         val current = openTypePriorityBase(preset)
         val updated = com.yagay.ListCleaner.domain.moveVisiblePriority(current, visible, packageName, offset)
         if (updated != current) app.rules.setOpenTypePriority(preset, updated)
     }
-    fun moveOpenTypePriorityTo(preset: OpenPreset, packageName: String, target: String, visible: List<String>, expected: List<String>) {
+
+    fun moveOpenTypePriorityTo(
+        preset: OpenPreset,
+        packageName: String,
+        target: String,
+        visible: List<String>,
+        expected: List<String>
+    ) {
         if (!canEdit()) return
-        val current = openTypePriorityBase(preset); if (current != expected) return
+        val current = openTypePriorityBase(preset)
+        if (current != expected) return
         val updated = com.yagay.ListCleaner.domain.moveVisiblePriorityTo(current, visible, packageName, target)
         if (updated != current) app.rules.setOpenTypePriority(preset, updated)
     }
-    fun resetOpenTypePriority(preset: OpenPreset) { if (canEdit()) app.rules.setOpenTypePriority(preset, emptyList()) }
+
+    fun resetOpenTypePriority(preset: OpenPreset) {
+        if (canEdit()) app.rules.setOpenTypePriority(preset, emptyList())
+    }
 
     fun requestScope() {
         if (scopeRequestInFlight) return
@@ -590,14 +788,25 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 val current = readModuleStatus(service)
                 check(app.service.value === service) { "服务连接已变化，请重新检查" }
                 check(current.scopeKnown) { current.error ?: "无法读取已授权作用域，未提交申请" }
-                check(current.detection.recommended.isNotEmpty()) { "未确认可自动申请的选择器宿主，请查看检测详情并在 LSPosed 中手动核查" }
+                check(current.detection.recommended.isNotEmpty()) {
+                    "未确认可自动申请的选择器宿主，请查看检测详情并在 LSPosed 中手动核查"
+                }
                 val missing = current.missingScope.toList()
-                if (missing.isEmpty()) { moduleStatus.value = current.copy(requesting = true, message = "检测到的推荐作用域均已授权，无需重复申请"); return@launch }
+                if (missing.isEmpty()) {
+                    moduleStatus.value = current.copy(requesting = true, message = "检测到的推荐作用域均已授权，无需重复申请")
+                    return@launch
+                }
                 val approved = withTimeoutOrNull(120_000) {
                     suspendCancellableCoroutine<List<String>> { continuation ->
                         service.requestScope(missing, object : XposedService.OnScopeEventListener {
-                            override fun onScopeRequestApproved(approved: List<String>) { if (continuation.isActive) continuation.resume(approved) }
-                            override fun onScopeRequestFailed(message: String) { if (continuation.isActive) continuation.resumeWithException(IllegalStateException(message)) }
+                            override fun onScopeRequestApproved(approved: List<String>) {
+                                if (continuation.isActive) continuation.resume(approved)
+                            }
+                            override fun onScopeRequestFailed(message: String) {
+                                if (continuation.isActive) {
+                                    continuation.resumeWithException(IllegalStateException(message))
+                                }
+                            }
                         })
                     }
                 }
@@ -610,13 +819,20 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     else -> "推荐作用域已确认授权；若目标尚未加载，请重新启动相关选择器，必要时重启设备"
                 }
                 moduleStatus.value = refreshed.copy(message = message)
-            } catch (cancelled: CancellationException) { throw cancelled }
-            catch (failure: Exception) { moduleStatus.value = moduleStatus.value.copy(error = failure.message ?: "申请作用域失败") }
-            finally { scopeRequestInFlight = false; moduleStatus.value = moduleStatus.value.copy(requesting = false) }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Exception) {
+                moduleStatus.value = moduleStatus.value.copy(error = failure.message ?: "申请作用域失败")
+            } finally {
+                scopeRequestInFlight = false
+                moduleStatus.value = moduleStatus.value.copy(requesting = false)
+            }
         }
     }
 
-    companion object { const val MAX_BACKUP_CHARS = RuleRepository.MAX_BACKUP_CHARS }
+    companion object {
+        const val MAX_BACKUP_CHARS = RuleRepository.MAX_BACKUP_CHARS
+    }
 }
 
 internal fun catalogVisible(item: ComponentCandidate, selected: Boolean, uiFilter: UiFilter): Boolean =

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
@@ -30,6 +30,9 @@ import com.yagay.ListCleaner.domain.ComponentRule
 import com.yagay.ListCleaner.domain.IntentKind
 import com.yagay.ListCleaner.domain.DisplayMode
 import com.yagay.ListCleaner.domain.PriorityConfig
+import com.yagay.ListCleaner.domain.DefaultOpenConfig
+import com.yagay.ListCleaner.domain.OpenPreset
+import com.yagay.ListCleaner.domain.OpenTypeConfig
 import io.github.libxposed.service.XposedService
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -94,6 +97,8 @@ data class MainState(
     val uiFilter: UiFilter = UiFilter.ALL,
     val diagnosticMode: Boolean = false,
     val priorities: PriorityConfig = PriorityConfig(),
+    val defaultOpen: DefaultOpenConfig = DefaultOpenConfig(),
+    val openTypes: OpenTypeConfig = OpenTypeConfig(),
     val tiles: TileConfig = TileConfig(),
     val hiddenFromApps: Set<String> = emptySet(),
     val groups: List<AppGroup> = emptyList(),
@@ -303,6 +308,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 report = DiagnosticCollector.collect(app, state.value.copy(
                     module = freshStatus, selected = config.rules, displayMode = config.mode,
                     priorities = config.priorities, diagnosticMode = config.diagnostic, tiles = config.tiles,
+                    openTypes = config.openTypes, defaultOpen = config.defaultOpen,
                     runtime = app.runtime.value,
                     syncStatus = app.syncStatus.value
                 ), mutableComponentScan.value, rootCatalog.lastOperation)
@@ -332,7 +338,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), ListContent(emptyList(), null, "", emptyList()))
     
     val state: StateFlow<MainState> = combine(
-        moduleStatus, loading, error, grouped, app.runtime, app.rules.displayMode, app.rules.priorities, app.rules.diagnosticMode, app.syncStatus, destination, expandedAppKey, app.rules.tiles, app.rules.hiddenFromApps
+        moduleStatus, loading, error, grouped, app.runtime, app.rules.displayMode, app.rules.priorities, app.rules.diagnosticMode, app.syncStatus, destination, expandedAppKey, app.rules.tiles, app.rules.hiddenFromApps, app.rules.defaultOpen, app.rules.openTypes
     ) { values ->
         @Suppress("UNCHECKED_CAST")
         MainState(
@@ -353,6 +359,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             expandedAppKey = values[10] as String?,
             tiles = values[11] as TileConfig,
             hiddenFromApps = values[12] as Set<String>,
+            defaultOpen = values[13] as DefaultOpenConfig,
+            openTypes = values[14] as OpenTypeConfig,
             uiFilter = (values[3] as ListContent).uiFilter
         )
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), MainState())
@@ -371,6 +379,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         refreshModuleStatus()
     }
 
+    fun setDefaultOpen(preset: OpenPreset, ruleId: String?) {
+        if (!canEdit()) return
+        app.rules.setDefaultOpen(preset, ruleId)
+    }
+
     fun setHiddenFromApps(packages: Set<String>) {
         app.rules.setHiddenFromApps(packages)
         viewModelScope.launch { app.synchronize() }
@@ -383,13 +396,15 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             loading.value = true
             error.value = null
             try {
-                candidates.value = app.catalog.completeConfigured(candidates.value, app.rules.rules.value)
+                val configured = app.rules.rules.value + app.rules.openTypes.value.rules.values.flatten().mapNotNull(ComponentRule::fromId)
+                candidates.value = app.catalog.completeConfigured(candidates.value, configured)
                 check(app.synchronize()) { app.runtime.value.message }
                 val result = app.catalog.scan()
                 check(app.synchronize()) { app.runtime.value.message }
                 if (generation == refreshGeneration) {
                     // Replace the directory, do not accumulate historical scan results.
-                    candidates.value = app.catalog.completeConfigured(result, app.rules.rules.value)
+                    val configured = app.rules.rules.value + app.rules.openTypes.value.rules.values.flatten().mapNotNull(ComponentRule::fromId)
+                    candidates.value = app.catalog.completeConfigured(result, configured)
                     error.value = app.catalog.scanWarning
                 }
             } catch (cancelled: CancellationException) {
@@ -503,6 +518,16 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     }
     fun toggle(rule: ComponentRule) { if (canEdit()) app.rules.toggle(rule) }
     fun setGroupSelected(group: AppGroup, selected: Boolean) { if (canEdit()) app.rules.setSelected(group.components.map { it.rule }, selected) }
+    fun toggleOpenType(preset: OpenPreset, rule: ComponentRule) { if (canEdit()) app.rules.toggleOpenType(preset, rule) }
+    fun setOpenTypeGroupSelected(preset: OpenPreset, group: AppGroup, selected: Boolean) {
+        if (canEdit()) app.rules.setOpenTypeSelected(preset, group.components.map { it.rule }, selected)
+    }
+    fun selectOpenTypeRules(preset: OpenPreset, rules: Collection<ComponentRule>) {
+        if (canEdit() && rules.isNotEmpty()) app.rules.setOpenTypeSelected(preset, rules.distinct(), true)
+    }
+    fun invertOpenTypeRules(preset: OpenPreset, rules: Collection<ComponentRule>) {
+        if (canEdit() && rules.isNotEmpty()) app.rules.invertOpenTypeSelected(preset, rules)
+    }
     fun selectRules(rules: Collection<ComponentRule>) {
         if (!canEdit() || rules.isEmpty()) return
         app.rules.setSelected(rules.distinct(), true)
@@ -568,6 +593,41 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         if (current != expected) return
         val updated = com.yagay.ListCleaner.domain.moveVisiblePriorityTo(current, visible, packageName, target)
         if (updated != current) app.rules.setPriority(kind, updated)
+    }
+
+    fun selectOpenTypePriorityApps(preset: OpenPreset, packageNames: Collection<String>) {
+        if (!canEdit()) return
+        val current = app.rules.openTypes.value.priorities[preset].orEmpty()
+        val next = (current + packageNames.distinct().filter { it !in current }).take(200)
+        if (next != current) app.rules.setOpenTypePriority(preset, next)
+    }
+    fun invertOpenTypePriorityApps(preset: OpenPreset, packageNames: Collection<String>) {
+        if (!canEdit()) return
+        val visible = packageNames.distinct(); if (visible.isEmpty()) return
+        val current = app.rules.openTypes.value.priorities[preset].orEmpty()
+        val retained = current.filterNot { it in visible.toSet() }
+        val next = (retained + visible.filter { it !in current }).take(200)
+        if (next != current) app.rules.setOpenTypePriority(preset, next)
+    }
+    fun pinOpenTypeApp(preset: OpenPreset, packageName: String) {
+        if (!canEdit()) return
+        val current = app.rules.openTypes.value.priorities[preset].orEmpty()
+        if (packageName !in current && current.size < 200) app.rules.setOpenTypePriority(preset, current + packageName)
+    }
+    fun removeOpenTypePriority(preset: OpenPreset, packageName: String) {
+        if (canEdit()) app.rules.setOpenTypePriority(preset, app.rules.openTypes.value.priorities[preset].orEmpty() - packageName)
+    }
+    fun moveOpenTypePriority(preset: OpenPreset, packageName: String, offset: Int, visible: List<String>) {
+        if (!canEdit()) return
+        val current = app.rules.openTypes.value.priorities[preset].orEmpty()
+        app.rules.setOpenTypePriority(preset, com.yagay.ListCleaner.domain.moveVisiblePriority(current, visible, packageName, offset))
+    }
+    fun moveOpenTypePriorityTo(preset: OpenPreset, packageName: String, target: String, visible: List<String>, expected: List<String>) {
+        if (!canEdit()) return
+        val current = app.rules.openTypes.value.priorities[preset].orEmpty()
+        if (current != expected) return
+        val updated = com.yagay.ListCleaner.domain.moveVisiblePriorityTo(current, visible, packageName, target)
+        if (updated != current) app.rules.setOpenTypePriority(preset, updated)
     }
 
     fun requestScope() {

--- a/app/src/main/java/com/yagay/ListCleaner/ui/OpenPresetFilterRow.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/OpenPresetFilterRow.kt
@@ -1,0 +1,24 @@
+package com.yagay.ListCleaner.ui
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.yagay.ListCleaner.domain.OpenPreset
+
+@Composable
+fun OpenPresetFilterRow(selected: OpenPreset?, onSelected: (OpenPreset?) -> Unit, modifier: Modifier = Modifier) {
+    val presets = OpenPreset.entries.filter { it != OpenPreset.BROWSER }
+    LazyRow(modifier, contentPadding = PaddingValues(horizontal = 8.dp)) {
+        item("all") {
+            FilterChip(selected = selected == null, onClick = { onSelected(null) }, label = { Text("全部") })
+        }
+        items(presets, key = { it.name }) { preset ->
+            FilterChip(selected = selected == preset, onClick = { onSelected(preset) }, label = { Text(preset.title) })
+        }
+    }
+}

--- a/app/src/main/java/com/yagay/ListCleaner/ui/OpenPresetFilterRow.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/OpenPresetFilterRow.kt
@@ -18,32 +18,27 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.yagay.ListCleaner.domain.OpenPreset
+import com.yagay.ListCleaner.domain.OpenTypeConfig
 
-/**
- * Secondary OPEN-type tabs. Keep the visual language identical to the primary IntentKind tabs:
- * text labels with a short underline for the active item, instead of a separate chip style.
- */
+/** Secondary OPEN-type tabs using the same visual language as the primary IntentKind tabs. */
 @Composable
 fun OpenPresetFilterRow(
     selected: OpenPreset?,
+    config: OpenTypeConfig,
     onSelected: (OpenPreset?) -> Unit,
+    onManageCustom: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val presets = OpenPreset.entries.filter { it != OpenPreset.BROWSER }
+    val presets = config.configuredPresets()
     LazyRow(modifier, contentPadding = PaddingValues(horizontal = 12.dp)) {
         item("all") {
-            OpenPresetTab(
-                title = "全部",
-                selected = selected == null,
-                onClick = { onSelected(null) }
-            )
+            OpenPresetTab("全部", selected == null) { onSelected(null) }
         }
         items(presets, key = { it.name }) { preset ->
-            OpenPresetTab(
-                title = preset.title,
-                selected = selected == preset,
-                onClick = { onSelected(preset) }
-            )
+            OpenPresetTab(config.titleFor(preset), selected == preset) { onSelected(preset) }
+        }
+        item("manage-custom") {
+            OpenPresetTab("+ 自定义", false, onManageCustom)
         }
     }
 }
@@ -55,14 +50,11 @@ private fun OpenPresetTab(title: String, selected: Boolean, onClick: () -> Unit)
             Text(
                 title,
                 fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
-                color = if (selected) MaterialTheme.colorScheme.primary
-                else MaterialTheme.colorScheme.onSurfaceVariant
+                color = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
             )
         }
         Box(
-            Modifier
-                .height(2.dp)
-                .width(24.dp)
+            Modifier.height(2.dp).width(24.dp)
                 .background(if (selected) MaterialTheme.colorScheme.primary else Color.Transparent)
         )
     }

--- a/app/src/main/java/com/yagay/ListCleaner/ui/OpenPresetFilterRow.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/OpenPresetFilterRow.kt
@@ -1,24 +1,69 @@
 package com.yagay.ListCleaner.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.yagay.ListCleaner.domain.OpenPreset
 
+/**
+ * Secondary OPEN-type tabs. Keep the visual language identical to the primary IntentKind tabs:
+ * text labels with a short underline for the active item, instead of a separate chip style.
+ */
 @Composable
-fun OpenPresetFilterRow(selected: OpenPreset?, onSelected: (OpenPreset?) -> Unit, modifier: Modifier = Modifier) {
+fun OpenPresetFilterRow(
+    selected: OpenPreset?,
+    onSelected: (OpenPreset?) -> Unit,
+    modifier: Modifier = Modifier
+) {
     val presets = OpenPreset.entries.filter { it != OpenPreset.BROWSER }
-    LazyRow(modifier, contentPadding = PaddingValues(horizontal = 8.dp)) {
+    LazyRow(modifier, contentPadding = PaddingValues(horizontal = 12.dp)) {
         item("all") {
-            FilterChip(selected = selected == null, onClick = { onSelected(null) }, label = { Text("全部") })
+            OpenPresetTab(
+                title = "全部",
+                selected = selected == null,
+                onClick = { onSelected(null) }
+            )
         }
         items(presets, key = { it.name }) { preset ->
-            FilterChip(selected = selected == preset, onClick = { onSelected(preset) }, label = { Text(preset.title) })
+            OpenPresetTab(
+                title = preset.title,
+                selected = selected == preset,
+                onClick = { onSelected(preset) }
+            )
         }
+    }
+}
+
+@Composable
+private fun OpenPresetTab(title: String, selected: Boolean, onClick: () -> Unit) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        TextButton(onClick = onClick) {
+            Text(
+                title,
+                fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+                color = if (selected) MaterialTheme.colorScheme.primary
+                else MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Box(
+            Modifier
+                .height(2.dp)
+                .width(24.dp)
+                .background(if (selected) MaterialTheme.colorScheme.primary else Color.Transparent)
+        )
     }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/ui/OpenUiPolicy.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/OpenUiPolicy.kt
@@ -1,0 +1,26 @@
+package com.yagay.ListCleaner.ui
+
+import com.yagay.ListCleaner.domain.ComponentRule
+import com.yagay.ListCleaner.domain.IntentKind
+import com.yagay.ListCleaner.domain.OpenTypeConfig
+import com.yagay.ListCleaner.domain.PriorityConfig
+
+/** Pure UI projection: raw persisted typed config + generic OPEN inheritance -> effective typed config. */
+internal fun effectiveOpenTypes(
+    raw: OpenTypeConfig,
+    selected: Set<ComponentRule>,
+    priorities: PriorityConfig
+): OpenTypeConfig {
+    val genericIds = selected.asSequence().filter { it.kind == IntentKind.OPEN }.map { it.id }.toSet()
+    val genericPriority = priorities.apps[IntentKind.OPEN].orEmpty()
+    val rules = raw.configuredPresets().mapNotNull { preset ->
+        val ids = genericIds + raw.rules[preset].orEmpty()
+        if (ids.isEmpty()) null else preset to ids
+    }.toMap()
+    val ranked = raw.configuredPresets().mapNotNull { preset ->
+        val explicit = raw.priorities[preset].orEmpty()
+        val packages = if (explicit.isNotEmpty()) explicit else genericPriority
+        if (packages.isEmpty()) null else preset to packages
+    }.toMap()
+    return raw.copy(rules = rules, priorities = ranked)
+}

--- a/app/src/main/java/com/yagay/ListCleaner/ui/PriorityDialog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/PriorityDialog.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.yagay.ListCleaner.domain.ComponentCandidate
 import com.yagay.ListCleaner.domain.IntentKind
+import com.yagay.ListCleaner.domain.OpenPreset
+import com.yagay.ListCleaner.domain.matchesOpenPreset
 import com.yagay.ListCleaner.domain.priorityCandidates
 import com.yagay.ListCleaner.domain.priorityAppGroups
 import com.yagay.ListCleaner.domain.PriorityListFilter
@@ -49,20 +51,24 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
             onDismiss = { editingTitle = null })
     }
     var kind by rememberSaveable { mutableStateOf(state.filter ?: IntentKind.SHARE) }
+    var openPreset by rememberSaveable { mutableStateOf<OpenPreset?>(null) }
     var viewFilter by rememberSaveable { mutableStateOf(UiFilter.ALL) }
     var expandedKey by rememberSaveable { mutableStateOf<String?>(null) }
-    val rankedRaw = state.priorities.apps[kind].orEmpty()
-    val groups = remember(state.candidates, state.selected, state.displayMode, kind, rankedRaw, state.query, viewFilter) {
-        priorityAppGroups(state.candidates, state.selected, state.displayMode, kind, rankedRaw, state.query,
+    LaunchedEffect(kind) { if (kind != IntentKind.OPEN) openPreset = null }
+    val typedSelected = openPreset?.let { state.openTypes.selectedRules(it) }.orEmpty()
+    val scopedCandidates = if (kind == IntentKind.OPEN && openPreset != null) state.candidates.filter { it.matchesOpenPreset(openPreset!!) } else state.candidates
+    val rankedRaw = if (kind == IntentKind.OPEN && openPreset != null) state.openTypes.priorities[openPreset].orEmpty() else state.priorities.apps[kind].orEmpty()
+    val groups = remember(scopedCandidates, state.selected, typedSelected, state.displayMode, kind, openPreset, rankedRaw, state.query, viewFilter) {
+        priorityAppGroups(scopedCandidates, state.selected, state.displayMode, kind, rankedRaw, state.query,
             when (viewFilter) {
                 UiFilter.ALL -> PriorityListFilter.ALL
                 UiFilter.HIDE_SELECTED -> PriorityListFilter.UNSELECTED
                 UiFilter.SHOW_SELECTED -> PriorityListFilter.SELECTED
-            })
+            }, typedSelected)
     }
     // Search narrows the move targets too; hidden saved slots remain untouched.
     val moveTargets = groups.filter { it.rank != null }.sortedBy { it.rank }.map { it.packageName }
-    val visibleSaved = priorityCandidates(state.candidates, state.selected, state.displayMode, kind)
+    val visibleSaved = priorityCandidates(scopedCandidates, state.selected, state.displayMode, kind, typedSelected)
         .map { it.rule.packageName }.toSet()
     val hiddenSavedCount = rankedRaw.count { it !in visibleSaved }
 
@@ -76,7 +82,7 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
     val edge = with(density) { 56.dp.toPx() }
     val speed = with(density) { 640.dp.toPx() }
     // Changing category/search/filter, importing or refreshing invalidates the gesture snapshot.
-    LaunchedEffect(kind, viewFilter, state.query, rankedRaw, moveTargets) { dragState.cancel() }
+    LaunchedEffect(kind, openPreset, viewFilter, state.query, rankedRaw, moveTargets) { dragState.cancel() }
     DisposableEffect(dragState) { onDispose { dragState.cancel() } }
     LaunchedEffect(drag?.packageName) {
         if (dragState.session != null) {
@@ -95,7 +101,7 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
     }
 
     Box(Modifier.fillMaxSize()) {
-    LazyColumn(Modifier.fillMaxSize().pointerInput(kind, viewFilter, state.query) {
+    LazyColumn(Modifier.fillMaxSize().pointerInput(kind, openPreset, viewFilter, state.query) {
         detectDragGesturesAfterLongPress(
             onDragStart = { position ->
                 if (dragState.start(position.y, kind.name, currentVisible, currentSaved)) {
@@ -108,7 +114,8 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
             onDragCancel = { dragState.cancel() },
             onDragEnd = {
                 dragState.finish()?.let { finished ->
-                    vm.movePriorityTo(kind, finished.packageName, finished.target, finished.visible, finished.saved)
+                    if (kind == IntentKind.OPEN && openPreset != null) vm.moveOpenTypePriorityTo(openPreset!!, finished.packageName, finished.target, finished.visible, finished.saved)
+                    else vm.movePriorityTo(kind, finished.packageName, finished.target, finished.visible, finished.saved)
                 }
             }
         )
@@ -119,6 +126,7 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
         }
         stickyHeader(key = "controls") {
             Surface(tonalElevation = 2.dp) {
+                Column {
                 ListControls(state.copy(filter = kind, uiFilter = viewFilter),
                     onFilter = { entry -> if (entry != null) { kind = entry; expandedKey = null } },
                     onUiFilter = { viewFilter = it }, includeAllKinds = false,
@@ -127,8 +135,10 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
                         UiFilter.HIDE_SELECTED -> "未优先"
                         UiFilter.SHOW_SELECTED -> "已优先"
                     } },
-                    onSelectAll = { vm.selectPriorityApps(kind, groups.map { it.packageName }) },
-                    onInvert = { vm.invertPriorityApps(kind, groups.map { it.packageName }) })
+                    onSelectAll = { if (kind == IntentKind.OPEN && openPreset != null) vm.selectOpenTypePriorityApps(openPreset!!, groups.map { it.packageName }) else vm.selectPriorityApps(kind, groups.map { it.packageName }) },
+                    onInvert = { if (kind == IntentKind.OPEN && openPreset != null) vm.invertOpenTypePriorityApps(openPreset!!, groups.map { it.packageName }) else vm.invertPriorityApps(kind, groups.map { it.packageName }) })
+                if (kind == IntentKind.OPEN) OpenPresetFilterRow(openPreset, { openPreset = it })
+                }
             }
         }
         item(key = "summary") {
@@ -159,7 +169,7 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
         }
         groups.forEach { group ->
             val packageName = group.packageName
-            val key = "${kind.name}|$packageName"
+            val key = "${kind.name}|${openPreset?.name ?: "ALL"}|$packageName"
             val expanded = expandedKey == key
             val onExpand = { expandedKey = if (expanded) null else key }
             val first = group.components.first()
@@ -179,7 +189,9 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
                     verticalAlignment = Alignment.CenterVertically) {
                     Checkbox(checked = group.rank != null, enabled = group.rank != null || rankedRaw.size < 200,
                         onCheckedChange = { checked ->
-                            if (checked) vm.pinApp(kind, packageName) else vm.removePriority(kind, packageName)
+                            if (kind == IntentKind.OPEN && openPreset != null) {
+                                if (checked) vm.pinOpenTypeApp(openPreset!!, packageName) else vm.removeOpenTypePriority(openPreset!!, packageName)
+                            } else if (checked) vm.pinApp(kind, packageName) else vm.removePriority(kind, packageName)
                         })
                     AppIcon(first.appIcon, first.appLabel)
                     Column(Modifier.weight(1f).padding(start = 10.dp)) {
@@ -199,10 +211,10 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
                     val index = moveTargets.indexOf(packageName)
                     Row(Modifier.fillMaxWidth().padding(start = 24.dp, end = 16.dp), verticalAlignment = Alignment.CenterVertically) {
                         Text("优先第 ${group.rank} 位", Modifier.weight(1f), style = MaterialTheme.typography.labelMedium)
-                        TextButton(onClick = { vm.movePriority(kind, packageName, -1, moveTargets) }, enabled = index > 0) {
+                        TextButton(onClick = { if (kind == IntentKind.OPEN && openPreset != null) vm.moveOpenTypePriority(openPreset!!, packageName, -1, moveTargets) else vm.movePriority(kind, packageName, -1, moveTargets) }, enabled = index > 0) {
                             Icon(Icons.Rounded.ArrowUpward, null, Modifier.size(18.dp)); Text("上移")
                         }
-                        TextButton(onClick = { vm.movePriority(kind, packageName, 1, moveTargets) },
+                        TextButton(onClick = { if (kind == IntentKind.OPEN && openPreset != null) vm.moveOpenTypePriority(openPreset!!, packageName, 1, moveTargets) else vm.movePriority(kind, packageName, 1, moveTargets) },
                             enabled = index >= 0 && index < moveTargets.lastIndex) {
                             Icon(Icons.Rounded.ArrowDownward, null, Modifier.size(18.dp)); Text("下移")
                         }

--- a/app/src/main/java/com/yagay/ListCleaner/ui/PriorityDialog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/PriorityDialog.kt
@@ -148,7 +148,9 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
                     style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Text("长按已优先应用可拖动排序，松手保存；展开后也可上移、下移。展开组件后点铅笔可修改该组件在当前 Intent 分类中的菜单显示名称，留空保存恢复原名称。",
                     style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text("排序和显示名称都按 Intent 分类保存，同一组件在分享、打开方式等分类中可设置不同名称。改名只改变候选菜单展示文字，不修改应用名、Activity 名或实际跳转目标；“全部显示”模式下暂停应用自定义名称。规则要求清理的组件不显示；未知厂商自定义菜单若不读取标准 ResolveInfo 标签，改名可能不生效。",
+                Text(if (kind == IntentKind.OPEN && openPreset != null)
+                    "当前正在编辑“打开方式 · ${openPreset!!.title}”排序。若该类型还没有专用排序，会直接继承并显示“全部”中的 OPEN 通用排序；第一次在当前类型里勾选、取消、拖动或上下移动时，会以继承顺序为基础创建该类型自己的专用排序。已有专用排序后以专用排序为准，不再跟随“全部”后续变化。"
+                    else "排序和显示名称都按 Intent 分类保存，同一组件在分享、打开方式等分类中可设置不同名称。改名只改变候选菜单展示文字，不修改应用名、Activity 名或实际跳转目标；“全部显示”模式下暂停应用自定义名称。规则要求清理的组件不显示；未知厂商自定义菜单若不读取标准 ResolveInfo 标签，改名可能不生效。",
                     style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 val compatibility = when {
                     !state.module.connected -> "LSPosed 未连接：可以保存，但尚未生效。"

--- a/app/src/main/java/com/yagay/ListCleaner/ui/PriorityDialog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/PriorityDialog.kt
@@ -57,6 +57,10 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
     LaunchedEffect(kind) { if (kind != IntentKind.OPEN) openPreset = null }
     val typedSelected = openPreset?.let { state.openTypes.selectedRules(it) }.orEmpty()
     val scopedCandidates = if (kind == IntentKind.OPEN && openPreset != null) state.candidates.filter { it.matchesOpenPreset(openPreset!!) } else state.candidates
+    val explicitTypedPriority = openPreset?.let { state.openTypesExplicit.priorities[it].orEmpty() }.orEmpty()
+    val genericOpenPriority = state.priorities.apps[IntentKind.OPEN].orEmpty()
+    val inheritsOpenPriority = kind == IntentKind.OPEN && openPreset != null && explicitTypedPriority.isEmpty() && genericOpenPriority.isNotEmpty()
+    val hasExplicitOpenPriority = kind == IntentKind.OPEN && openPreset != null && explicitTypedPriority.isNotEmpty()
     val rankedRaw = if (kind == IntentKind.OPEN && openPreset != null) state.openTypes.priorities[openPreset].orEmpty() else state.priorities.apps[kind].orEmpty()
     val groups = remember(scopedCandidates, state.selected, typedSelected, state.displayMode, kind, openPreset, rankedRaw, state.query, viewFilter) {
         priorityAppGroups(scopedCandidates, state.selected, state.displayMode, kind, rankedRaw, state.query,
@@ -66,7 +70,6 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
                 UiFilter.SHOW_SELECTED -> PriorityListFilter.SELECTED
             }, typedSelected)
     }
-    // Search narrows the move targets too; hidden saved slots remain untouched.
     val moveTargets = groups.filter { it.rank != null }.sortedBy { it.rank }.map { it.packageName }
     val visibleSaved = priorityCandidates(scopedCandidates, state.selected, state.displayMode, kind, typedSelected)
         .map { it.rule.packageName }.toSet()
@@ -81,7 +84,6 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
     val density = LocalDensity.current
     val edge = with(density) { 56.dp.toPx() }
     val speed = with(density) { 640.dp.toPx() }
-    // Changing category/search/filter, importing or refreshing invalidates the gesture snapshot.
     LaunchedEffect(kind, openPreset, viewFilter, state.query, rankedRaw, moveTargets) { dragState.cancel() }
     DisposableEffect(dragState) { onDispose { dragState.cancel() } }
     LaunchedEffect(drag?.packageName) {
@@ -148,19 +150,37 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
                     style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 Text("长按已优先应用可拖动排序，松手保存；展开后也可上移、下移。展开组件后点铅笔可修改该组件在当前 Intent 分类中的菜单显示名称，留空保存恢复原名称。",
                     style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text(if (kind == IntentKind.OPEN && openPreset != null)
-                    "当前正在编辑“打开方式 · ${openPreset!!.title}”排序。若该类型还没有专用排序，会直接继承并显示“全部”中的 OPEN 通用排序；第一次在当前类型里勾选、取消、拖动或上下移动时，会以继承顺序为基础创建该类型自己的专用排序。已有专用排序后以专用排序为准，不再跟随“全部”后续变化。"
-                    else "排序和显示名称都按 Intent 分类保存，同一组件在分享、打开方式等分类中可设置不同名称。改名只改变候选菜单展示文字，不修改应用名、Activity 名或实际跳转目标；“全部显示”模式下暂停应用自定义名称。规则要求清理的组件不显示；未知厂商自定义菜单若不读取标准 ResolveInfo 标签，改名可能不生效。",
-                    style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                if (kind == IntentKind.OPEN && openPreset != null) {
+                    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            when {
+                                inheritsOpenPriority -> "当前排序来源：继承“打开方式 · 全部”"
+                                hasExplicitOpenPriority -> "当前排序来源：${openPreset!!.title} 专用排序"
+                                else -> "当前类型和“全部”都没有优先排序"
+                            },
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = if (inheritsOpenPriority) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        if (hasExplicitOpenPriority) {
+                            TextButton(onClick = { vm.resetOpenTypePriority(openPreset!!) }) { Text("恢复继承全部") }
+                        }
+                    }
+                    Text("没有专用排序时直接继承“全部”；第一次在当前类型里勾选、取消、拖动或上下移动会以继承顺序为基础创建专用排序。恢复继承后会重新跟随“全部”的后续变化。",
+                        style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                } else {
+                    Text("排序和显示名称都按 Intent 分类保存。同一组件在分享、打开方式等分类中可设置不同名称；改名只改变候选菜单展示文字，不修改应用名、Activity 名或实际跳转目标。",
+                        style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
                 val compatibility = when {
                     !state.module.connected -> "LSPosed 未连接：可以保存，但尚未生效。"
                     state.module.detection.hosts.isEmpty() -> "未确认选择器宿主，当前设备排序能力未知。"
                     state.module.detection.hosts.any { it.packageName != "system" && !it.className.startsWith("com.android.internal.app.") && !it.className.startsWith("com.android.intentresolver.") } ->
                         "厂商独立排序路径尚未适配；仅走 AOSP 路径时可能有效，不能保证置顶。"
-                    else -> "已实现 AOSP 路径适配，未确认本机命中。保存后重新打开选择器核对。"
+                    else -> "已实现 AOSP 路径适配；状态页会显示排序 Hook 的实际命中次数。"
                 }
                 Text(if (!state.runtime.ready) state.runtime.message else if (kind == IntentKind.PROCESS_TEXT)
-                    "文本候选按查询结果排序；来源应用若自行重排，仍可能不同。保存后重新打开文本菜单。" else compatibility,
+                    "文本候选按查询结果排序；来源应用若自行重排，仍可能不同。" else compatibility,
                     style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 if (hiddenSavedCount > 0) Text("$hiddenSavedCount 项因已清理或本次未匹配而暂不显示，排序配置保留。",
                     style = MaterialTheme.typography.bodySmall)
@@ -198,7 +218,9 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
                     AppIcon(first.appIcon, first.appLabel)
                     Column(Modifier.weight(1f).padding(start = 10.dp)) {
                         Text(first.appLabel, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.Medium)
-                        Text((group.rank?.let { "优先第 $it 位" } ?: "未优先") + " · ${group.components.size} 个组件",
+                        Text((group.rank?.let { "优先第 $it 位" } ?: "未优先") +
+                            (if (group.rank != null && inheritsOpenPriority) " · 继承自全部" else "") +
+                            " · ${group.components.size} 个组件",
                             style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                     }
                     IconButton(onClick = onExpand) {
@@ -212,7 +234,7 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
                 if (group.rank != null) item(key = "order|$key") {
                     val index = moveTargets.indexOf(packageName)
                     Row(Modifier.fillMaxWidth().padding(start = 24.dp, end = 16.dp), verticalAlignment = Alignment.CenterVertically) {
-                        Text("优先第 ${group.rank} 位", Modifier.weight(1f), style = MaterialTheme.typography.labelMedium)
+                        Text("优先第 ${group.rank} 位" + if (inheritsOpenPriority) " · 继承" else "", Modifier.weight(1f), style = MaterialTheme.typography.labelMedium)
                         TextButton(onClick = { if (kind == IntentKind.OPEN && openPreset != null) vm.moveOpenTypePriority(openPreset!!, packageName, -1, moveTargets) else vm.movePriority(kind, packageName, -1, moveTargets) }, enabled = index > 0) {
                             Icon(Icons.Rounded.ArrowUpward, null, Modifier.size(18.dp)); Text("上移")
                         }

--- a/app/src/main/java/com/yagay/ListCleaner/ui/PriorityDialog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/PriorityDialog.kt
@@ -45,18 +45,31 @@ import com.yagay.ListCleaner.domain.PriorityListFilter
 @Composable
 fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
     var editingTitle by remember { mutableStateOf<ComponentCandidate?>(null) }
+    var showCustomTypes by rememberSaveable { mutableStateOf(false) }
     editingTitle?.let { item ->
         ComponentTitleDialog(item, state.priorities.titles[item.rule.id],
             onSave = { vm.setComponentTitle(item.rule.id, it) },
             onDismiss = { editingTitle = null })
+    }
+    if (showCustomTypes) {
+        CustomOpenTypeDialog(
+            config = state.openTypesExplicit,
+            onSave = vm::setCustomOpenDefinition,
+            onDismiss = { showCustomTypes = false }
+        )
     }
     var kind by rememberSaveable { mutableStateOf(state.filter ?: IntentKind.SHARE) }
     var openPreset by rememberSaveable { mutableStateOf<OpenPreset?>(null) }
     var viewFilter by rememberSaveable { mutableStateOf(UiFilter.ALL) }
     var expandedKey by rememberSaveable { mutableStateOf<String?>(null) }
     LaunchedEffect(kind) { if (kind != IntentKind.OPEN) openPreset = null }
+    LaunchedEffect(state.openTypesExplicit.customDefinitions, openPreset) {
+        if (openPreset?.isCustom == true && openPreset !in state.openTypesExplicit.customDefinitions) openPreset = null
+    }
     val typedSelected = openPreset?.let { state.openTypes.selectedRules(it) }.orEmpty()
-    val scopedCandidates = if (kind == IntentKind.OPEN && openPreset != null) state.candidates.filter { it.matchesOpenPreset(openPreset!!) } else state.candidates
+    val scopedCandidates = if (kind == IntentKind.OPEN && openPreset != null) {
+        state.candidates.filter { it.matchesOpenPreset(openPreset!!, state.openTypesExplicit.customDefinitions) }
+    } else state.candidates
     val explicitTypedPriority = openPreset?.let { state.openTypesExplicit.priorities[it].orEmpty() }.orEmpty()
     val genericOpenPriority = state.priorities.apps[IntentKind.OPEN].orEmpty()
     val inheritsOpenPriority = kind == IntentKind.OPEN && openPreset != null && explicitTypedPriority.isEmpty() && genericOpenPriority.isNotEmpty()
@@ -103,180 +116,177 @@ fun PriorityDialogContent(state: MainState, vm: MainViewModel) {
     }
 
     Box(Modifier.fillMaxSize()) {
-    LazyColumn(Modifier.fillMaxSize().pointerInput(kind, openPreset, viewFilter, state.query) {
-        detectDragGesturesAfterLongPress(
-            onDragStart = { position ->
-                if (dragState.start(position.y, kind.name, currentVisible, currentSaved)) {
-                    haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+        LazyColumn(Modifier.fillMaxSize().pointerInput(kind, openPreset, viewFilter, state.query) {
+            detectDragGesturesAfterLongPress(
+                onDragStart = { position ->
+                    if (dragState.start(position.y, kind.name, currentVisible, currentSaved)) {
+                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                    }
+                },
+                onDrag = { change, amount -> if (dragState.session != null) { change.consume(); dragState.move(amount.y) } },
+                onDragCancel = { dragState.cancel() },
+                onDragEnd = {
+                    dragState.finish()?.let { finished ->
+                        if (kind == IntentKind.OPEN && openPreset != null) vm.moveOpenTypePriorityTo(openPreset!!, finished.packageName, finished.target, finished.visible, finished.saved)
+                        else vm.movePriorityTo(kind, finished.packageName, finished.target, finished.visible, finished.saved)
+                    }
                 }
-            },
-            onDrag = { change, amount ->
-                if (dragState.session != null) { change.consume(); dragState.move(amount.y) }
-            },
-            onDragCancel = { dragState.cancel() },
-            onDragEnd = {
-                dragState.finish()?.let { finished ->
-                    if (kind == IntentKind.OPEN && openPreset != null) vm.moveOpenTypePriorityTo(openPreset!!, finished.packageName, finished.target, finished.visible, finished.saved)
-                    else vm.movePriorityTo(kind, finished.packageName, finished.target, finished.visible, finished.saved)
-                }
+            )
+        }, state = listState, contentPadding = PaddingValues(bottom = 16.dp)) {
+            item(key = "status") {
+                ModuleStatusRow(state, compact = true) { vm.setDestination(Destination.DASHBOARD) }
+                if (state.runtime.needsDecision) RuntimePanel(state, vm, showUpdateTools = false)
             }
-        )
-    }, state = listState, contentPadding = PaddingValues(bottom = 16.dp)) {
-        item(key = "status") {
-            ModuleStatusRow(state, compact = true) { vm.setDestination(Destination.DASHBOARD) }
-            if (state.runtime.needsDecision) RuntimePanel(state, vm, showUpdateTools = false)
-        }
-        stickyHeader(key = "controls") {
-            Surface(tonalElevation = 2.dp) {
-                Column {
-                ListControls(state.copy(filter = kind, uiFilter = viewFilter),
-                    onFilter = { entry -> if (entry != null) { kind = entry; expandedKey = null } },
-                    onUiFilter = { viewFilter = it }, includeAllKinds = false,
-                    viewTitle = { when (it) {
-                        UiFilter.ALL -> "全部"
-                        UiFilter.HIDE_SELECTED -> "未优先"
-                        UiFilter.SHOW_SELECTED -> "已优先"
-                    } },
-                    onSelectAll = { if (kind == IntentKind.OPEN && openPreset != null) vm.selectOpenTypePriorityApps(openPreset!!, groups.map { it.packageName }) else vm.selectPriorityApps(kind, groups.map { it.packageName }) },
-                    onInvert = { if (kind == IntentKind.OPEN && openPreset != null) vm.invertOpenTypePriorityApps(openPreset!!, groups.map { it.packageName }) else vm.invertPriorityApps(kind, groups.map { it.packageName }) })
-                if (kind == IntentKind.OPEN) OpenPresetFilterRow(openPreset, { openPreset = it })
-                }
-            }
-        }
-        item(key = "summary") {
-            Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                Text("应用列表 · ${groups.size}", style = MaterialTheme.typography.labelLarge)
-                Text("勾选控制应用的优先顺序；自定义显示名称是独立功能，不需要把应用加入优先列表。",
-                    style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                Text("长按已优先应用可拖动排序，松手保存；展开后也可上移、下移。展开组件后点铅笔可修改该组件在当前 Intent 分类中的菜单显示名称，留空保存恢复原名称。",
-                    style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                if (kind == IntentKind.OPEN && openPreset != null) {
-                    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            when {
-                                inheritsOpenPriority -> "当前排序来源：继承“打开方式 · 全部”"
-                                hasExplicitOpenPriority -> "当前排序来源：${openPreset!!.title} 专用排序"
-                                else -> "当前类型和“全部”都没有优先排序"
-                            },
-                            modifier = Modifier.weight(1f),
-                            style = MaterialTheme.typography.labelMedium,
-                            color = if (inheritsOpenPriority) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        if (hasExplicitOpenPriority) {
-                            TextButton(onClick = { vm.resetOpenTypePriority(openPreset!!) }) { Text("恢复继承全部") }
+            stickyHeader(key = "controls") {
+                Surface(tonalElevation = 2.dp) {
+                    Column {
+                        ListControls(state.copy(filter = kind, uiFilter = viewFilter),
+                            onFilter = { entry -> if (entry != null) { kind = entry; expandedKey = null } },
+                            onUiFilter = { viewFilter = it }, includeAllKinds = false,
+                            viewTitle = { when (it) {
+                                UiFilter.ALL -> "全部"
+                                UiFilter.HIDE_SELECTED -> "未优先"
+                                UiFilter.SHOW_SELECTED -> "已优先"
+                            } },
+                            onSelectAll = { if (kind == IntentKind.OPEN && openPreset != null) vm.selectOpenTypePriorityApps(openPreset!!, groups.map { it.packageName }) else vm.selectPriorityApps(kind, groups.map { it.packageName }) },
+                            onInvert = { if (kind == IntentKind.OPEN && openPreset != null) vm.invertOpenTypePriorityApps(openPreset!!, groups.map { it.packageName }) else vm.invertPriorityApps(kind, groups.map { it.packageName }) })
+                        if (kind == IntentKind.OPEN) {
+                            OpenPresetFilterRow(
+                                selected = openPreset,
+                                config = state.openTypesExplicit,
+                                onSelected = { openPreset = it },
+                                onManageCustom = { showCustomTypes = true }
+                            )
                         }
                     }
-                    Text("没有专用排序时直接继承“全部”；第一次在当前类型里勾选、取消、拖动或上下移动会以继承顺序为基础创建专用排序。恢复继承后会重新跟随“全部”的后续变化。",
+                }
+            }
+            item(key = "summary") {
+                Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                    val presetTitle = openPreset?.let(state.openTypes::titleFor)
+                    Text("应用列表 · ${groups.size}" + (presetTitle?.let { " · $it" } ?: ""), style = MaterialTheme.typography.labelLarge)
+                    Text("勾选控制应用的优先顺序；自定义显示名称是独立功能，不需要把应用加入优先列表。",
                         style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                } else {
-                    Text("排序和显示名称都按 Intent 分类保存。同一组件在分享、打开方式等分类中可设置不同名称；改名只改变候选菜单展示文字，不修改应用名、Activity 名或实际跳转目标。",
+                    Text("长按已优先应用可拖动排序，松手保存；展开后也可上移、下移。展开组件后点铅笔可修改该组件在当前 Intent 分类中的菜单显示名称，留空保存恢复原名称。",
                         style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    if (kind == IntentKind.OPEN && openPreset != null) {
+                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                when {
+                                    inheritsOpenPriority -> "当前排序来源：继承“打开方式 · 全部”"
+                                    hasExplicitOpenPriority -> "当前排序来源：$presetTitle 专用排序"
+                                    else -> "当前类型和“全部”都没有优先排序"
+                                },
+                                modifier = Modifier.weight(1f),
+                                style = MaterialTheme.typography.labelMedium,
+                                color = if (inheritsOpenPriority) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            if (hasExplicitOpenPriority) TextButton(onClick = { vm.resetOpenTypePriority(openPreset!!) }) { Text("恢复继承全部") }
+                        }
+                        Text("没有专用排序时直接继承“全部”；第一次在当前类型里勾选、取消、拖动或上下移动会以继承顺序为基础创建专用排序。恢复继承后会重新跟随“全部”的后续变化。自定义类型与内置类型使用同一套逻辑。",
+                            style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    } else {
+                        Text("排序和显示名称都按 Intent 分类保存。同一组件在分享、打开方式等分类中可设置不同名称；改名只改变候选菜单展示文字，不修改应用名、Activity 名或实际跳转目标。",
+                            style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    }
+                    val compatibility = when {
+                        !state.module.connected -> "LSPosed 未连接：可以保存，但尚未生效。"
+                        state.module.detection.hosts.isEmpty() -> "未确认选择器宿主，当前设备排序能力未知。"
+                        state.module.detection.hosts.any { it.packageName != "system" && !it.className.startsWith("com.android.internal.app.") && !it.className.startsWith("com.android.intentresolver.") } ->
+                            "厂商独立排序路径尚未适配；仅走 AOSP 路径时可能有效，不能保证置顶。"
+                        else -> "已实现 AOSP 路径适配；诊断模式可确认 Resolver 侧 ORDER_DELIVERED。"
+                    }
+                    Text(if (!state.runtime.ready) state.runtime.message else if (kind == IntentKind.PROCESS_TEXT)
+                        "文本候选按查询结果排序；来源应用若自行重排，仍可能不同。" else compatibility,
+                        style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    if (hiddenSavedCount > 0) Text("$hiddenSavedCount 项因已清理或本次未匹配而暂不显示，排序配置保留。", style = MaterialTheme.typography.bodySmall)
+                    if (rankedRaw.size >= 200) Text("当前分类已达 200 项上限，取消部分优先后可继续添加。", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+                    if (state.error != null) Text("本次刷新未完整完成，详情见状态页", color = MaterialTheme.colorScheme.error)
                 }
-                val compatibility = when {
-                    !state.module.connected -> "LSPosed 未连接：可以保存，但尚未生效。"
-                    state.module.detection.hosts.isEmpty() -> "未确认选择器宿主，当前设备排序能力未知。"
-                    state.module.detection.hosts.any { it.packageName != "system" && !it.className.startsWith("com.android.internal.app.") && !it.className.startsWith("com.android.intentresolver.") } ->
-                        "厂商独立排序路径尚未适配；仅走 AOSP 路径时可能有效，不能保证置顶。"
-                    else -> "已实现 AOSP 路径适配；状态页会显示排序 Hook 的实际命中次数。"
-                }
-                Text(if (!state.runtime.ready) state.runtime.message else if (kind == IntentKind.PROCESS_TEXT)
-                    "文本候选按查询结果排序；来源应用若自行重排，仍可能不同。" else compatibility,
-                    style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                if (hiddenSavedCount > 0) Text("$hiddenSavedCount 项因已清理或本次未匹配而暂不显示，排序配置保留。",
-                    style = MaterialTheme.typography.bodySmall)
-                if (rankedRaw.size >= 200) Text("当前分类已达 200 项上限，取消部分优先后可继续添加。",
-                    style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
-                if (state.error != null) Text("本次刷新未完整完成，详情见状态页", color = MaterialTheme.colorScheme.error)
             }
-        }
-        groups.forEach { group ->
-            val packageName = group.packageName
-            val key = "${kind.name}|${openPreset?.name ?: "ALL"}|$packageName"
-            val expanded = expandedKey == key
-            val onExpand = { expandedKey = if (expanded) null else key }
-            val first = group.components.first()
-            item(key = "app|$key", contentType = "app") {
-                val marker = MaterialTheme.colorScheme.primary
-                Row(Modifier.fillMaxWidth()
-                    .alpha(if (drag?.packageName == packageName) 0.3f else 1f)
-                    .drawWithContent {
-                        drawContent()
-                        if (drag?.target == packageName && drag.packageName != packageName) {
-                            val y = if (drag.movingDown) size.height - 2.dp.toPx() else 2.dp.toPx()
-                            drawLine(marker, Offset(0f, y), Offset(size.width, y), 3.dp.toPx())
+            groups.forEach { group ->
+                val packageName = group.packageName
+                val key = "${kind.name}|${openPreset?.name ?: "ALL"}|$packageName"
+                val expanded = expandedKey == key
+                val onExpand = { expandedKey = if (expanded) null else key }
+                val first = group.components.first()
+                item(key = "app|$key", contentType = "app") {
+                    val marker = MaterialTheme.colorScheme.primary
+                    Row(Modifier.fillMaxWidth()
+                        .alpha(if (drag?.packageName == packageName) 0.3f else 1f)
+                        .drawWithContent {
+                            drawContent()
+                            if (drag?.target == packageName && drag.packageName != packageName) {
+                                val y = if (drag.movingDown) size.height - 2.dp.toPx() else 2.dp.toPx()
+                                drawLine(marker, Offset(0f, y), Offset(size.width, y), 3.dp.toPx())
+                            }
+                        }
+                        .clickable(onClickLabel = if (expanded) "折叠" else "展开", onClick = onExpand)
+                        .heightIn(min = 64.dp).padding(horizontal = 8.dp, vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(checked = group.rank != null, enabled = group.rank != null || rankedRaw.size < 200,
+                            onCheckedChange = { checked ->
+                                if (kind == IntentKind.OPEN && openPreset != null) {
+                                    if (checked) vm.pinOpenTypeApp(openPreset!!, packageName) else vm.removeOpenTypePriority(openPreset!!, packageName)
+                                } else if (checked) vm.pinApp(kind, packageName) else vm.removePriority(kind, packageName)
+                            })
+                        AppIcon(first.appIcon, first.appLabel)
+                        Column(Modifier.weight(1f).padding(start = 10.dp)) {
+                            Text(first.appLabel, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.Medium)
+                            Text((group.rank?.let { "优先第 $it 位" } ?: "未优先") +
+                                (if (group.rank != null && inheritsOpenPriority) " · 继承自全部" else "") +
+                                " · ${group.components.size} 个组件",
+                                style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                        }
+                        IconButton(onClick = onExpand) {
+                            Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore, if (expanded) "折叠" else "展开")
                         }
                     }
-                    .clickable(onClickLabel = if (expanded) "折叠" else "展开", onClick = onExpand)
-                    .heightIn(min = 64.dp).padding(horizontal = 8.dp, vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically) {
-                    Checkbox(checked = group.rank != null, enabled = group.rank != null || rankedRaw.size < 200,
-                        onCheckedChange = { checked ->
-                            if (kind == IntentKind.OPEN && openPreset != null) {
-                                if (checked) vm.pinOpenTypeApp(openPreset!!, packageName) else vm.removeOpenTypePriority(openPreset!!, packageName)
-                            } else if (checked) vm.pinApp(kind, packageName) else vm.removePriority(kind, packageName)
-                        })
-                    AppIcon(first.appIcon, first.appLabel)
-                    Column(Modifier.weight(1f).padding(start = 10.dp)) {
-                        Text(first.appLabel, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.Medium)
-                        Text((group.rank?.let { "优先第 $it 位" } ?: "未优先") +
-                            (if (group.rank != null && inheritsOpenPriority) " · 继承自全部" else "") +
-                            " · ${group.components.size} 个组件",
-                            style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                    }
-                    IconButton(onClick = onExpand) {
-                        Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
-                            if (expanded) "折叠" else "展开")
-                    }
+                    HorizontalDivider()
                 }
-                HorizontalDivider()
-            }
-            if (expanded) {
-                if (group.rank != null) item(key = "order|$key") {
-                    val index = moveTargets.indexOf(packageName)
-                    Row(Modifier.fillMaxWidth().padding(start = 24.dp, end = 16.dp), verticalAlignment = Alignment.CenterVertically) {
-                        Text("优先第 ${group.rank} 位" + if (inheritsOpenPriority) " · 继承" else "", Modifier.weight(1f), style = MaterialTheme.typography.labelMedium)
-                        TextButton(onClick = { if (kind == IntentKind.OPEN && openPreset != null) vm.moveOpenTypePriority(openPreset!!, packageName, -1, moveTargets) else vm.movePriority(kind, packageName, -1, moveTargets) }, enabled = index > 0) {
-                            Icon(Icons.Rounded.ArrowUpward, null, Modifier.size(18.dp)); Text("上移")
-                        }
-                        TextButton(onClick = { if (kind == IntentKind.OPEN && openPreset != null) vm.moveOpenTypePriority(openPreset!!, packageName, 1, moveTargets) else vm.movePriority(kind, packageName, 1, moveTargets) },
-                            enabled = index >= 0 && index < moveTargets.lastIndex) {
-                            Icon(Icons.Rounded.ArrowDownward, null, Modifier.size(18.dp)); Text("下移")
+                if (expanded) {
+                    if (group.rank != null) item(key = "order|$key") {
+                        val index = moveTargets.indexOf(packageName)
+                        Row(Modifier.fillMaxWidth().padding(start = 24.dp, end = 16.dp), verticalAlignment = Alignment.CenterVertically) {
+                            Text("优先第 ${group.rank} 位" + if (inheritsOpenPriority) " · 继承" else "", Modifier.weight(1f), style = MaterialTheme.typography.labelMedium)
+                            TextButton(onClick = { if (kind == IntentKind.OPEN && openPreset != null) vm.moveOpenTypePriority(openPreset!!, packageName, -1, moveTargets) else vm.movePriority(kind, packageName, -1, moveTargets) }, enabled = index > 0) {
+                                Icon(Icons.Rounded.ArrowUpward, null, Modifier.size(18.dp)); Text("上移")
+                            }
+                            TextButton(onClick = { if (kind == IntentKind.OPEN && openPreset != null) vm.moveOpenTypePriority(openPreset!!, packageName, 1, moveTargets) else vm.movePriority(kind, packageName, 1, moveTargets) }, enabled = index >= 0 && index < moveTargets.lastIndex) {
+                                Icon(Icons.Rounded.ArrowDownward, null, Modifier.size(18.dp)); Text("下移")
+                            }
                         }
                     }
+                    items(group.components, key = { "component|${it.rule.id}" }, contentType = { "component" }) { item ->
+                        ComponentInfoRow(item, state.priorities.titles[item.rule.id]) { editingTitle = item }
+                    }
                 }
-                items(group.components, key = { "component|${it.rule.id}" }, contentType = { "component" }) { item ->
-                    ComponentInfoRow(item, state.priorities.titles[item.rule.id]) { editingTitle = item }
+            }
+            if (!state.loading && groups.isEmpty()) item(key = "empty") {
+                Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
+                    Text(when {
+                        state.query.isNotBlank() -> "没有匹配的应用"
+                        viewFilter == UiFilter.SHOW_SELECTED -> "当前没有可显示的优先应用"
+                        viewFilter == UiFilter.HIDE_SELECTED -> "当前没有可显示的未优先应用"
+                        else -> "当前分类没有可排序的应用"
+                    })
                 }
             }
         }
-        if (!state.loading && groups.isEmpty()) item(key = "empty") {
-            Box(Modifier.fillMaxWidth().padding(32.dp), contentAlignment = Alignment.Center) {
-                Text(when {
-                    state.query.isNotBlank() -> "没有匹配的应用"
-                    viewFilter == UiFilter.SHOW_SELECTED -> "当前没有可显示的优先应用"
-                    viewFilter == UiFilter.HIDE_SELECTED -> "当前没有可显示的未优先应用"
-                    else -> "当前分类没有可排序的应用"
-                })
-            }
-        }
-    }
-    drag?.let { moving ->
-        groups.firstOrNull { it.packageName == moving.packageName }?.let { group ->
-            val first = group.components.first()
-            Surface(Modifier.fillMaxWidth().offset { IntOffset(0, moving.top.roundToInt()) }.zIndex(1f),
-                tonalElevation = 6.dp, shadowElevation = 8.dp) {
-                Row(Modifier.heightIn(min = 64.dp).padding(horizontal = 16.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically) {
-                    AppIcon(first.appIcon, first.appLabel)
-                    Column(Modifier.weight(1f).padding(start = 10.dp)) {
-                        Text(first.appLabel, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.Medium)
-                        Text("松手移动到优先第 ${groups.firstOrNull { it.packageName == moving.target }?.rank} 位",
-                            style = MaterialTheme.typography.bodySmall)
+        drag?.let { moving ->
+            groups.firstOrNull { it.packageName == moving.packageName }?.let { group ->
+                val first = group.components.first()
+                Surface(Modifier.fillMaxWidth().offset { IntOffset(0, moving.top.roundToInt()) }.zIndex(1f), tonalElevation = 6.dp, shadowElevation = 8.dp) {
+                    Row(Modifier.heightIn(min = 64.dp).padding(horizontal = 16.dp, vertical = 8.dp), verticalAlignment = Alignment.CenterVertically) {
+                        AppIcon(first.appIcon, first.appLabel)
+                        Column(Modifier.weight(1f).padding(start = 10.dp)) {
+                            Text(first.appLabel, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.Medium)
+                            Text("松手移动到优先第 ${groups.firstOrNull { it.packageName == moving.target }?.rank} 位", style = MaterialTheme.typography.bodySmall)
+                        }
                     }
                 }
             }
         }
-    }
     }
 }
 

--- a/app/src/main/java/com/yagay/ListCleaner/ui/RootComponentsController.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/RootComponentsController.kt
@@ -1,0 +1,135 @@
+package com.yagay.ListCleaner.ui
+
+import com.yagay.ListCleaner.ListCleanerApp
+import com.yagay.ListCleaner.data.ComponentRootCommand
+import com.yagay.ListCleaner.data.RootComponent
+import com.yagay.ListCleaner.data.RootComponentCatalog
+import com.yagay.ListCleaner.data.RootComponentScan
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/** Owns Root component scanning/mutation state so MainViewModel can focus on resolver rules and module state. */
+internal class RootComponentsController(
+    app: ListCleanerApp,
+    private val scope: CoroutineScope
+) {
+    private val catalog = RootComponentCatalog(app)
+
+    private val mutableScan = MutableStateFlow(RootComponentScan())
+    val scan: StateFlow<RootComponentScan> = mutableScan
+
+    private val mutableBusy = MutableStateFlow(false)
+    val busy: StateFlow<Boolean> = mutableBusy
+
+    private val mutableMessage = MutableStateFlow<String?>(null)
+    val message: StateFlow<String?> = mutableMessage
+
+    private val mutableRootNotice = MutableStateFlow<String?>(null)
+    val rootNotice: StateFlow<String?> = mutableRootNotice
+
+    val lastOperation: String get() = catalog.lastOperation
+
+    fun dismissRootNotice() { mutableRootNotice.value = null }
+
+    fun refresh() {
+        if (mutableBusy.value) return
+        mutableBusy.value = true
+        scope.launch {
+            try {
+                mutableScan.value = withContext(Dispatchers.IO) { catalog.scan() }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (failure: Exception) {
+                mutableMessage.value = failure.message ?: "扫描失败"
+            } finally {
+                mutableBusy.value = false
+            }
+        }
+    }
+
+    fun change(target: RootComponent, enable: Boolean) = change(listOf(target), enable)
+
+    fun change(visibleTargets: List<RootComponent>, enable: Boolean) {
+        if (mutableBusy.value) return
+        val targets = visibleTargets.filter {
+            it.blocked == null && it.enabled != null && it.enabled != enable
+        }.distinctBy { "${it.user}|${it.component.flattenToString()}" }
+        if (targets.isEmpty()) return
+        mutableRootNotice.value = null
+        mutableBusy.value = true
+        mutableMessage.value = "正在请求 Root 并核验系统状态…"
+        scope.launch {
+            withContext(NonCancellable + Dispatchers.IO) {
+                var completed = 0
+                var operationStarted = false
+                try {
+                    catalog.requireRoot()
+                    var result = ""
+                    for (target in targets) {
+                        operationStarted = true
+                        mutableMessage.value = "正在${if (enable) "启用" else "禁用"} ${completed + 1}/${targets.size}：${target.label}"
+                        result = catalog.change(target, enable)
+                        completed++
+                    }
+                    mutableMessage.value = if (targets.size == 1) result
+                    else "已核验：$completed 个组件已${if (enable) "启用" else "禁用"}；请重新打开目标选择器"
+                } catch (failure: ComponentRootCommand.RootAccessException) {
+                    mutableMessage.value = failure.message
+                    mutableRootNotice.value = failure.message
+                } catch (failure: Exception) {
+                    mutableMessage.value = "已完成 $completed/${targets.size}，操作已停止：${failure.message ?: "操作失败"}。失败项请核对系统状态；剩余项未执行，已完成项不回滚。"
+                } finally {
+                    if (operationStarted) refreshAfterMutation()
+                    mutableBusy.value = false
+                }
+            }
+        }
+    }
+
+    fun invert(visibleTargets: List<RootComponent>) {
+        if (mutableBusy.value) return
+        val targets = visibleTargets.filter {
+            it.blocked == null && it.enabled != null
+        }.distinctBy { "${it.user}|${it.component.flattenToString()}" }
+        if (targets.isEmpty()) return
+        mutableRootNotice.value = null
+        mutableBusy.value = true
+        mutableMessage.value = "正在请求 Root 并反选组件…"
+        scope.launch {
+            withContext(NonCancellable + Dispatchers.IO) {
+                var completed = 0
+                var operationStarted = false
+                try {
+                    catalog.requireRoot()
+                    for (target in targets) {
+                        operationStarted = true
+                        mutableMessage.value = "正在反选 ${completed + 1}/${targets.size}：${target.label}"
+                        catalog.change(target, target.enabled == false)
+                        completed++
+                    }
+                    mutableMessage.value = "已核验：$completed 个组件已反选；请重新打开目标选择器"
+                } catch (failure: ComponentRootCommand.RootAccessException) {
+                    mutableMessage.value = failure.message
+                    mutableRootNotice.value = failure.message
+                } catch (failure: Exception) {
+                    mutableMessage.value = "已完成 $completed/${targets.size}，反选已停止：${failure.message ?: "操作失败"}。已完成项不回滚。"
+                } finally {
+                    if (operationStarted) refreshAfterMutation()
+                    mutableBusy.value = false
+                }
+            }
+        }
+    }
+
+    private fun refreshAfterMutation() {
+        runCatching { catalog.scan() }
+            .onSuccess { mutableScan.value = it }
+            .onFailure { mutableScan.value = RootComponentScan(warning = "操作后扫描失败，请刷新；不使用旧状态") }
+    }
+}

--- a/app/src/main/java/com/yagay/ListCleaner/ui/RootComponentsScreen.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/RootComponentsScreen.kt
@@ -23,6 +23,17 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.yagay.ListCleaner.data.CleanupKind
+import com.yagay.ListCleaner.data.RootComponent
+
+private fun componentAppSelectionRank(items: List<RootComponent>): Int {
+    val editable = items.filter { it.blocked == null && it.enabled != null }
+    val disabledCount = editable.count { it.enabled == false }
+    return when {
+        editable.isNotEmpty() && disabledCount == editable.size -> 0
+        disabledCount > 0 -> 1
+        else -> 2
+    }
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -58,7 +69,11 @@ fun RootComponentsScreen(state: MainState, vm: MainViewModel) {
             (state.query.isBlank() || listOf(it.label, it.owner, it.component.flattenToString()).any { text -> text.contains(state.query, true) })
     }
     val groups = visible.groupBy { "${it.user}|${it.component.packageName}" }.entries
-        .sortedWith(compareBy({ it.value.first().owner.lowercase() }, { it.key }))
+        .sortedWith(
+            compareBy<Map.Entry<String, List<RootComponent>>> { componentAppSelectionRank(it.value) }
+                .thenBy { it.value.first().owner.lowercase() }
+                .thenBy { it.key }
+        )
 
     LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = 16.dp)) {
         item(key = "title") {

--- a/app/src/main/java/com/yagay/ListCleaner/ui/RootComponentsScreen.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/RootComponentsScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.ExpandMore
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
@@ -35,32 +36,35 @@ fun RootComponentsScreen(state: MainState, vm: MainViewModel) {
             onDismissRequest = vm::dismissComponentRootNotice,
             title = { Text("需要 Root 授权") },
             text = { Text(notice) },
-            confirmButton = {
-                TextButton(onClick = vm::dismissComponentRootNotice) { Text("知道了") }
-            }
+            confirmButton = { TextButton(onClick = vm::dismissComponentRootNotice) { Text("知道了") } }
         )
     }
+
     var kind by remember { mutableStateOf<CleanupKind?>(null) }
     var viewFilter by remember { mutableStateOf(UiFilter.ALL) }
     var filterMenu by remember { mutableStateOf(false) }
+    var onlyModified by rememberSaveable { mutableStateOf(false) }
     var expandedAppKey by remember { mutableStateOf<String?>(null) }
     LaunchedEffect(Unit) { vm.refreshComponents() }
+
     val visible = scan.items.filter {
-        (kind == null || it.kind == kind) && (when (viewFilter) {
-            UiFilter.ALL -> true
-            UiFilter.SHOW_SELECTED -> it.enabled == false
-            UiFilter.HIDE_SELECTED -> it.enabled == true
-        }) &&
+        (kind == null || it.kind == kind) &&
+            (!onlyModified || it.modifiedByListCleaner) &&
+            (when (viewFilter) {
+                UiFilter.ALL -> true
+                UiFilter.SHOW_SELECTED -> it.enabled == false
+                UiFilter.HIDE_SELECTED -> it.enabled == true
+            }) &&
             (state.query.isBlank() || listOf(it.label, it.owner, it.component.flattenToString()).any { text -> text.contains(state.query, true) })
     }
-    // Package and user identify an app; display labels need not be unique.
     val groups = visible.groupBy { "${it.user}|${it.component.packageName}" }.entries
         .sortedWith(compareBy({ it.value.first().owner.lowercase() }, { it.key }))
+
     LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = 16.dp)) {
         item(key = "title") {
             Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
                 Text("组件清理 · Root", style = MaterialTheme.typography.titleLarge)
-        }
+            }
         }
         stickyHeader(key = "controls") {
             Surface(tonalElevation = 2.dp) {
@@ -69,11 +73,17 @@ fun RootComponentsScreen(state: MainState, vm: MainViewModel) {
                         items(listOf<CleanupKind?>(null) + CleanupKind.entries) { entry ->
                             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                                 TextButton(onClick = { kind = entry }) {
-                                    Text(entry?.title ?: "全部", fontWeight = if (kind == entry) FontWeight.Bold else FontWeight.Normal,
-                                        color = if (kind == entry) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant)
+                                    Text(
+                                        entry?.title ?: "全部",
+                                        fontWeight = if (kind == entry) FontWeight.Bold else FontWeight.Normal,
+                                        color = if (kind == entry) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
                                 }
-                                Box(Modifier.height(2.dp).width(24.dp).background(
-                                    if (kind == entry) MaterialTheme.colorScheme.primary else androidx.compose.ui.graphics.Color.Transparent))
+                                Box(
+                                    Modifier.height(2.dp).width(24.dp).background(
+                                        if (kind == entry) MaterialTheme.colorScheme.primary else androidx.compose.ui.graphics.Color.Transparent
+                                    )
+                                )
                             }
                         }
                     }
@@ -86,9 +96,11 @@ fun RootComponentsScreen(state: MainState, vm: MainViewModel) {
                             }
                             DropdownMenu(expanded = filterMenu, onDismissRequest = { filterMenu = false }) {
                                 UiFilter.entries.forEach { filter ->
-                                    DropdownMenuItem(text = { Text(filter.title) },
+                                    DropdownMenuItem(
+                                        text = { Text(filter.title) },
                                         leadingIcon = { if (viewFilter == filter) Icon(Icons.Rounded.Check, null) },
-                                        onClick = { viewFilter = filter; filterMenu = false })
+                                        onClick = { viewFilter = filter; filterMenu = false }
+                                    )
                                 }
                             }
                         }
@@ -102,30 +114,57 @@ fun RootComponentsScreen(state: MainState, vm: MainViewModel) {
                             enabled = !busy && visible.any { it.blocked == null && it.enabled != null }
                         ) { Text("反选") }
                     }
+                    Row(
+                        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text("只看本应用修改", Modifier.weight(1f), style = MaterialTheme.typography.bodySmall)
+                        Switch(checked = onlyModified, onCheckedChange = { onlyModified = it })
+                    }
                     if (busy) LinearProgressIndicator(Modifier.fillMaxWidth())
                     HorizontalDivider()
                 }
             }
         }
         item(key = "summary") {
-        Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-        Text("应用列表 · ${groups.size} · ${visible.size} 个组件", style = MaterialTheme.typography.labelLarge)
-        Text("计数仅针对当前可见组件；应用勾选仅操作其中可更改的组件，保护/未知状态项跳过。全部视图不会因勾选隐藏应用。",
-            style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text("勾选＝组件已禁用。直接读取系统状态，不保存名单，不区分由谁禁用。扫描无需 Root；更改时请求授权。清除本应用数据不改变系统状态。",
-            style = MaterialTheme.typography.bodySmall)
-        Text("勾选立即禁用，取消勾选立即明确启用，不再弹窗确认。禁用会影响正在使用此组件的功能；启用不是恢复原默认状态。",
-            style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        Text(when (kind) {
-            null -> "仅管理标准磁贴服务、快捷方式创建入口及小部件接收器；不是禁用整个应用。"
-            CleanupKind.TILE -> "仅列出标准 TileService。Wi-Fi、蓝牙等没有独立服务的系统内置磁贴不支持；核心系统组件仅展示。"
-            CleanupKind.SHORTCUT -> "标准快捷方式创建 Activity；不含动态快捷方式或 ShortX 私有项目。禁用后可能影响其他使用该 Activity 的入口。"
-            CleanupKind.WIDGET -> "带小部件声明的接收器。禁用可能使已放置的小部件失效；启用不保证恢复原布局。"
-        }, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-        if (scan.warning.isNotBlank()) Text(scan.warning, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
-        message?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+            Column(Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                Text("应用列表 · ${groups.size} · ${visible.size} 个组件", style = MaterialTheme.typography.labelLarge)
+                Text(
+                    "计数仅针对当前可见组件；应用勾选仅操作其中可更改的组件，保护/未知状态项跳过。全部视图不会因勾选隐藏应用。",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    "勾选＝组件已禁用。系统当前状态始终直接读取；“本应用修改”历史只在 Root 操作成功且系统状态核验成功后记录，用于筛选，不作为当前启用/禁用状态依据。",
+                    style = MaterialTheme.typography.bodySmall
+                )
+                Text(
+                    "勾选立即禁用，取消勾选立即明确启用，不再弹窗确认。禁用会影响正在使用此组件的功能；启用不是恢复原默认状态。清除应用数据不会改变系统组件状态，但会清除本应用修改历史。",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    when (kind) {
+                        null -> "仅管理标准磁贴服务、快捷方式创建入口及小部件接收器；不是禁用整个应用。"
+                        CleanupKind.TILE -> "仅列出标准 TileService。Wi-Fi、蓝牙等没有独立服务的系统内置磁贴不支持；核心系统组件仅展示。"
+                        CleanupKind.SHORTCUT -> "标准快捷方式创建 Activity；不含动态快捷方式或 ShortX 私有项目。禁用后可能影响其他使用该 Activity 的入口。"
+                        CleanupKind.WIDGET -> "带小部件声明的接收器。禁用可能使已放置的小部件失效；启用不保证恢复原布局。"
+                    },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (onlyModified) {
+                    Text(
+                        "当前只显示曾被 List Cleaner 成功修改过的组件；即使后来被其他工具再次改动，仍会保留历史标记。",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+                if (scan.warning.isNotBlank()) Text(scan.warning, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+                message?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
+            }
         }
-        }
+
         groups.forEach { (appKey, unsorted) ->
             val components = unsorted.sortedWith(compareBy({ it.kind.ordinal }, { it.label.lowercase() }, { it.id }))
             val editableComponents = components.filter { it.blocked == null && it.enabled != null }
@@ -138,59 +177,112 @@ fun RootComponentsScreen(state: MainState, vm: MainViewModel) {
             val first = components.first()
             val expansionKey = "${kind?.name ?: "ALL"}|$appKey"
             val expanded = expandedAppKey == expansionKey
-            val onExpand = {
-                expandedAppKey = if (expandedAppKey == expansionKey) null else expansionKey
-            }
+            val onExpand = { expandedAppKey = if (expandedAppKey == expansionKey) null else expansionKey }
+
             item(key = "app|$expansionKey") {
-                Row(Modifier.fillMaxWidth()
-                    .clickable(onClickLabel = if (expanded) "折叠" else "展开", onClick = onExpand)
-                    .heightIn(min = 64.dp).padding(horizontal = 8.dp, vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically) {
-                    TriStateCheckbox(state = selectionState, enabled = !busy && editableComponents.isNotEmpty(),
-                        onClick = { vm.changeComponents(editableComponents, selectionState == ToggleableState.On) })
+                Row(
+                    Modifier.fillMaxWidth()
+                        .clickable(onClickLabel = if (expanded) "折叠" else "展开", onClick = onExpand)
+                        .heightIn(min = 64.dp).padding(horizontal = 8.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    TriStateCheckbox(
+                        state = selectionState,
+                        enabled = !busy && editableComponents.isNotEmpty(),
+                        onClick = { vm.changeComponents(editableComponents, selectionState == ToggleableState.On) }
+                    )
                     AppIcon(first.icon, first.owner)
                     Column(Modifier.weight(1f).padding(start = 10.dp)) {
-                        Text(first.owner, maxLines = 1, overflow = TextOverflow.Ellipsis,
-                            fontWeight = FontWeight.Medium)
-                        Text("已禁用 ${components.count { it.enabled == false }}/${components.size} · ${components.map { it.kind.title }.distinct().joinToString("、")}",
+                        Text(first.owner, maxLines = 1, overflow = TextOverflow.Ellipsis, fontWeight = FontWeight.Medium)
+                        Text(
+                            "已禁用 ${components.count { it.enabled == false }}/${components.size} · ${components.map { it.kind.title }.distinct().joinToString("、")}",
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant)
-                        if (editableComponents.size < components.size) Text("${components.size - editableComponents.size} 项仅展示，不参与批量操作",
-                            style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        val modifiedCount = components.count { it.modifiedByListCleaner }
+                        if (modifiedCount > 0) {
+                            Text(
+                                "本应用修改历史 $modifiedCount 项",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                        if (editableComponents.size < components.size) {
+                            Text(
+                                "${components.size - editableComponents.size} 项仅展示，不参与批量操作",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
                     }
                     IconButton(onClick = onExpand) {
-                        Icon(if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
-                            if (expanded) "折叠" else "展开")
+                        Icon(
+                            if (expanded) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                            if (expanded) "折叠" else "展开"
+                        )
                     }
                 }
                 HorizontalDivider()
             }
+
             if (expanded) items(components, key = { it.id }) { item ->
                 val editable = !busy && item.blocked == null && item.enabled != null
-                Row(Modifier.fillMaxWidth()
-                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.25f))
-                    .toggleable(value = item.enabled == false, enabled = editable, role = Role.Checkbox,
-                        onValueChange = { checked -> vm.changeComponent(item, !checked) })
-                    .heightIn(min = 48.dp).padding(start = 16.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically) {
-                    Checkbox(checked = item.enabled == false, enabled = editable, onCheckedChange = null,
-                        modifier = Modifier.padding(12.dp))
+                Row(
+                    Modifier.fillMaxWidth()
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.25f))
+                        .toggleable(
+                            value = item.enabled == false,
+                            enabled = editable,
+                            role = Role.Checkbox,
+                            onValueChange = { checked -> vm.changeComponent(item, !checked) }
+                        )
+                        .heightIn(min = 48.dp).padding(start = 16.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Checkbox(
+                        checked = item.enabled == false,
+                        enabled = editable,
+                        onCheckedChange = null,
+                        modifier = Modifier.padding(12.dp)
+                    )
                     Column(Modifier.weight(1f)) {
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Text(item.label, modifier = Modifier.weight(1f), maxLines = 2, overflow = TextOverflow.Ellipsis)
                             Text(item.kind.title, style = MaterialTheme.typography.labelMedium)
                         }
-                        Text(item.component.flattenToShortString(), maxLines = 2, overflow = TextOverflow.Ellipsis, style = MaterialTheme.typography.labelSmall)
-                        Text(item.blocked ?: when (item.overrideState) {
-                            0 -> if (item.enabled == true) "默认启用" else "默认关闭"
-                            1 -> "明确启用"
-                            2, 3, 4 -> "已禁用（来源未知）"
-                            else -> "状态未知"
-                        }, style = MaterialTheme.typography.bodySmall)
+                        Text(
+                            item.component.flattenToShortString(),
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                            style = MaterialTheme.typography.labelSmall
+                        )
+                        Text(
+                            item.blocked ?: when (item.overrideState) {
+                                0 -> if (item.enabled == true) "默认启用" else "默认关闭"
+                                1 -> "明确启用"
+                                2, 3, 4 -> "已禁用（来源未知）"
+                                else -> "状态未知"
+                            },
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                        if (item.modifiedByListCleaner) {
+                            Text(
+                                "曾由 List Cleaner 成功修改",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
                     }
                 }
             }
         }
-        if (visible.isEmpty() && !busy) item { Text("没有匹配的组件", Modifier.padding(vertical = 16.dp)) }
-}
+        if (visible.isEmpty() && !busy) {
+            item {
+                Text(
+                    if (onlyModified) "没有符合条件的本应用修改历史" else "没有匹配的组件",
+                    Modifier.padding(vertical = 16.dp)
+                )
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
@@ -66,7 +66,15 @@ class ListCleanerModule : XposedModule() {
             val packageName = parts.getOrNull(1)?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
             kind to packageName
         }.groupBy({ it.first }, { it.second }).mapValues { (_, packages) -> packages.toSet() }
-        val allSelectedPackages: Set<String> = selectedPackages.values.flatten().toSet()
+        private val typedOpenPackages: Set<String> = openTypes.rules.values.asSequence().flatten().mapNotNull { id ->
+            val parts = id.split('|', limit = 3)
+            val kind = parts.getOrNull(0)?.let { runCatching { IntentKind.valueOf(it) }.getOrNull() }
+            if (kind != IntentKind.OPEN) return@mapNotNull null
+            parts.getOrNull(1)?.takeIf { it.isNotBlank() }
+        }.toSet()
+        // Package-visibility fallback is intentionally package-level. If ES is selected in
+        // hiddenFromApps, an app chosen only in a typed OPEN rule is hidden from ES as a whole.
+        val allSelectedPackages: Set<String> = selectedPackages.values.flatten().toSet() + typedOpenPackages
         fun hasSelection(kind: IntentKind): Boolean = kind in selectedKinds
         fun hasPackageSelection(kind: IntentKind, packageName: String): Boolean = packageName in selectedPackages[kind].orEmpty()
     }
@@ -416,7 +424,6 @@ class ListCleanerModule : XposedModule() {
         installFinalOrderingHooks(classLoader)
     }
 
-
     private fun installFinalOrderingHooks(loader: ClassLoader) {
         listOf("com.android.internal.app.ResolverListAdapter", "com.android.internal.app.ChooserListAdapter",
             "com.android.intentresolver.ResolverListAdapter", "com.android.intentresolver.ChooserListAdapter").forEach { name ->
@@ -480,7 +487,8 @@ class ListCleanerModule : XposedModule() {
         val effective = intent.selector ?: intent
         val context = runCatching { OrderingAccess.field(receiver, "mContext") as? Context }.getOrNull()
         val mime = effective.type ?: runCatching { context?.let { effective.resolveTypeIfNeeded(it.contentResolver) } }.getOrNull()
-        return matchOpenPreset(kind, mime, effective.data?.scheme)
+        val data = effective.data
+        return matchOpenPreset(kind, mime, data?.scheme, data?.lastPathSegment ?: data?.path)
     }
 
     private fun effectivePriorities(kind: IntentKind, preset: OpenPreset?, current: RuleSnapshot): List<String> {
@@ -656,7 +664,7 @@ class ListCleanerModule : XposedModule() {
                     Throwable().stackTrace.take(14).joinToString(" <- ") { "${it.className}.${it.methodName}" })
             }
             diagnostic("QUERY layer=$layer kind=$kind action=${intent.action} mime=${intent.type ?: resolvedType} " +
-                "scheme=${intent.data?.scheme} component=${intent.component?.flattenToShortString()} " +
+                "scheme=${intent.data?.scheme} file=${intent.data?.lastPathSegment} component=${intent.component?.flattenToShortString()} " +
                 "package=${intent.`package`} callerUid=$callerUid " +
                 "result=${original?.javaClass?.name} rules=${snapshot.configured.size} mode=${snapshot.displayMode}")
         }
@@ -672,13 +680,16 @@ class ListCleanerModule : XposedModule() {
             diagnostic("skip $layer ${intent.action}: unsupported result ${original?.javaClass?.name}")
             return original
         }
-        val replacement = transform(kind, extracted.values, layer, callerUid, intent.type ?: resolvedType, intent.data?.scheme) ?: return original
+        val data = intent.data
+        val replacement = transform(
+            kind, extracted.values, layer, callerUid, intent.type ?: resolvedType,
+            data?.scheme, data?.lastPathSegment ?: data?.path
+        ) ?: return original
         return runCatching { extracted.rebuild(replacement) }.getOrElse {
             Log.e(TAG, "Failed to rebuild ${original?.javaClass?.name}; keeping original", it)
             original
         }
     }
-
 
     private fun isSelectedCandidate(kind: IntentKind, activity: ActivityInfo, current: RuleSnapshot, layer: Layer): Boolean {
         val canonicalClass = com.yagay.ListCleaner.domain.ComponentIdentity.canonicalClassName(
@@ -688,7 +699,15 @@ class ListCleanerModule : XposedModule() {
         return false
     }
 
-    private fun transform(kind: IntentKind, values: List<*>, layer: Layer, callerUid: Int, mimeType: String?, scheme: String?): List<*>? {
+    private fun transform(
+        kind: IntentKind,
+        values: List<*>,
+        layer: Layer,
+        callerUid: Int,
+        mimeType: String?,
+        scheme: String?,
+        fileNameOrPath: String?
+    ): List<*>? {
         if (values.isEmpty()) { diagnostic("SKIP $layer $kind empty_input"); return null }
         val current = snapshot
         if (current.displayMode == DisplayMode.SHOW_ALL) {
@@ -696,7 +715,7 @@ class ListCleanerModule : XposedModule() {
             return null
         }
         var changed = false
-        val preset = matchOpenPreset(kind, mimeType, scheme)
+        val preset = matchOpenPreset(kind, mimeType, scheme, fileNameOrPath)
         val typedIds = if (kind == IntentKind.OPEN && preset != null) current.openTypes.rules[preset].orEmpty() else emptySet()
         val hasSelection = current.hasSelection(kind) || typedIds.isNotEmpty()
         val filtered = if (!hasSelection && current.displayMode != DisplayMode.SHOW_SELECTED) {
@@ -715,7 +734,7 @@ class ListCleanerModule : XposedModule() {
                 val candidateId = "${kind.name}|${activity.packageName}|$canonicalClass"
                 val selected = candidateId in current.configured || candidateId in typedIds
                 diagnostic(
-                    "CANDIDATE $layer $kind ${activity.packageName}/${activity.name} target=${activity.targetActivity} canonical=$canonicalClass selected=$selected match=${if (selected) "component" else "none"}",
+                    "CANDIDATE $layer $kind preset=$preset ${activity.packageName}/${activity.name} target=${activity.targetActivity} canonical=$canonicalClass selected=$selected match=${if (selected) "component" else "none"}",
                     detail = true
                 )
                 current.displayMode.includes(selected, hasSelection).also {
@@ -744,7 +763,7 @@ class ListCleanerModule : XposedModule() {
             diagnostic("NO_CHANGE $layer $kind size=${values.size} hasSelection=$hasSelection preset=$preset")
             return null
         }
-        diagnostic("$layer $kind: ${values.size} -> ${titled.size}")
+        diagnostic("$layer $kind preset=$preset: ${values.size} -> ${titled.size}")
         return titled
     }
 
@@ -804,7 +823,7 @@ class ListCleanerModule : XposedModule() {
                     config.priorities, config.defaultOpen, config.openTypes, config.diagnostic, config.managerAppId, digest, config.hiddenFromApps)
                 lastEncodedConfig = encoded
                 record("MANAGER_IDENTITY appId=${config.managerAppId} source=remote_config")
-                record("RULES_READ reason=$reason count=${snapshot.configured.size} mode=${config.mode} diagnostic=${config.diagnostic} atomic=true priorities=${config.priorities.apps.mapValues { it.value.size }} typedRules=${config.openTypes.rules.mapValues { it.value.size }} typedPriorities=${config.openTypes.priorities.mapValues { it.value.size }} titles=${config.priorities.titles.size} legacyDefaultOpenIgnored=${config.defaultOpen.preferred.size} hiddenFromApps=${config.hiddenFromApps.size} digest=$digest")
+                record("RULES_READ reason=$reason count=${snapshot.configured.size} mode=${config.mode} diagnostic=${config.diagnostic} atomic=true priorities=${config.priorities.apps.mapValues { it.value.size }} typedRules=${config.openTypes.rules.mapValues { it.value.size }} typedPriorities=${config.openTypes.priorities.mapValues { it.value.size }} titles=${config.priorities.titles.size} legacyDefaultOpenIgnored=${config.defaultOpen.preferred.size} hiddenFromApps=${config.hiddenFromApps.size} visibilityTargets=${snapshot.allSelectedPackages.size} digest=$digest")
                 record("LEGACY_TILE_CONFIG ignored=true enabled=${config.tiles.enabled} hidden=${config.tiles.hidden.size}")
                 return@runCatching
             }
@@ -863,7 +882,6 @@ class ListCleanerModule : XposedModule() {
             method.parameterTypes.any { Intent::class.java.isAssignableFrom(it) } &&
             (List::class.java.isAssignableFrom(method.returnType) ||
                 method.returnType.name == "android.content.pm.ParceledListSlice")
-
 
     private enum class Layer { SYSTEM, RESOLVER }
 

--- a/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
@@ -6,7 +6,6 @@ import android.content.SharedPreferences
 import android.content.pm.ResolveInfo
 import android.content.pm.ActivityInfo
 import android.content.pm.ApplicationInfo
-import android.content.pm.PackageManager
 import com.yagay.ListCleaner.BuildConfig
 import com.yagay.ListCleaner.domain.RuntimeProtocol
 import io.github.libxposed.api.XposedModuleInterface.HotReloadingParam
@@ -41,6 +40,7 @@ import kotlinx.serialization.json.Json
 import java.lang.reflect.Constructor
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Level 1 filters PackageManager resolver results. Level 2 runs only in system_server and adds
@@ -72,9 +72,9 @@ class ListCleanerModule : XposedModule() {
             if (kind != IntentKind.OPEN) return@mapNotNull null
             parts.getOrNull(1)?.takeIf { it.isNotBlank() }
         }.toSet()
-        // Package-visibility fallback is intentionally package-level. If ES is selected in
-        // hiddenFromApps, an app chosen only in a typed OPEN rule is hidden from ES as a whole.
-        val allSelectedPackages: Set<String> = selectedPackages.values.flatten().toSet() + typedOpenPackages
+        // Compatibility hiding is intentionally limited to OPEN targets. A caller such as ES
+        // should not lose an app merely because that app is selected in SHARE or PROCESS_TEXT.
+        val allSelectedPackages: Set<String> = selectedPackages[IntentKind.OPEN].orEmpty() + typedOpenPackages
         fun hasSelection(kind: IntentKind): Boolean = kind in selectedKinds
         fun hasPackageSelection(kind: IntentKind, packageName: String): Boolean = packageName in selectedPackages[kind].orEmpty()
     }
@@ -84,8 +84,7 @@ class ListCleanerModule : XposedModule() {
     @Volatile
     private var snapshot = RuleSnapshot(emptySet(), DisplayMode.HIDE_SELECTED, PriorityConfig(), DefaultOpenConfig(), OpenTypeConfig(), false)
     private var lastEncodedConfig: String? = null
-    @Volatile
-    private var listenerRegistered = false
+    @Volatile private var listenerRegistered = false
     private var processName = ""
     private var systemServer = false
     private var diagnosticWindow = 0L
@@ -97,6 +96,9 @@ class ListCleanerModule : XposedModule() {
     private val queryInProgress = ThreadLocal<Boolean>()
     private val installedMethods = ConcurrentHashMap.newKeySet<String>()
     private val tracedActions = ConcurrentHashMap.newKeySet<String>()
+    private val queryHits = AtomicLong()
+    private val visibilityHits = AtomicLong()
+    private val orderingHits = AtomicLong()
     private val preferences by lazy(LazyThreadSafetyMode.PUBLICATION) {
         getRemotePreferences(RuleRepository.REMOTE_PREFS)
     }
@@ -302,8 +304,6 @@ class ListCleanerModule : XposedModule() {
     private fun systemVisibilityHooker(adapter: VisibilityLayout) = XposedInterface.Hooker { chain ->
         pollPreferences()
         val current = snapshot
-        // Package-level hiding is intentionally limited to HIDE_SELECTED. SHOW_SELECTED at package
-        // visibility level would hide unrelated packages and can break the caller process.
         if (current.displayMode != DisplayMode.HIDE_SELECTED ||
             current.hiddenFromApps.isEmpty() || current.allSelectedPackages.isEmpty()) {
             return@Hooker chain.proceed()
@@ -313,8 +313,6 @@ class ListCleanerModule : XposedModule() {
         val callingUid = args.getOrNull(adapter.uidIndex) as? Int ?: return@Hooker chain.proceed()
         if (callingUid < 10_000) return@Hooker chain.proceed()
 
-        // Newer Android exposes a Computer/PackageDataSnapshot object; Android 12 does not, so
-        // fall back to the calling SettingBase/PackageSetting supplied by AppsFilter itself.
         val computer = args.firstOrNull { value -> value != null && hasGetPackagesForUid(value.javaClass) }
         val callers = if (computer != null) packagesForUid(computer, callingUid)
             else packageNamesFromCallerSetting(adapter.callerSettingIndex?.let(args::getOrNull))
@@ -325,6 +323,7 @@ class ListCleanerModule : XposedModule() {
             return@Hooker chain.proceed()
         }
 
+        visibilityHits.incrementAndGet()
         diagnostic("SYSTEM_VISIBILITY_FILTER uid=$callingUid caller=${callers.sorted()} target=$target")
         true
     }
@@ -469,7 +468,7 @@ class ListCleanerModule : XposedModule() {
         recordOrderingCapability()
     }
 
-    private fun recordOrderingCapability() = record("ORDER_CAPABILITY ranked=${installedMethods.any { it.startsWith("ORDER#") }} alphaBoundary=${installedMethods.any { it.startsWith("ALPHA#") }} execution=unverified")
+    private fun recordOrderingCapability() = record("ORDER_CAPABILITY ranked=${installedMethods.any { it.startsWith("ORDER#") }} alphaBoundary=${installedMethods.any { it.startsWith("ALPHA#") }} hits=${orderingHits.get()}")
 
     private fun adapterKind(receiver: Any): IntentKind? {
         val intent = OrderingAccess.targetIntent(receiver) as? Intent ?: return null
@@ -478,7 +477,7 @@ class ListCleanerModule : XposedModule() {
         val mime = effective.type ?: runCatching {
             context?.let { effective.resolveTypeIfNeeded(it.contentResolver) }
         }.getOrNull()
-        return intent.intentKind(mime)
+        return effective.intentKind(mime)
     }
 
     private fun adapterOpenPreset(receiver: Any, kind: IntentKind): OpenPreset? {
@@ -545,7 +544,10 @@ class ListCleanerModule : XposedModule() {
             null
         }
         val result = if (replacement == null) chain.proceed() else chain.proceed(replacement)
-        if (replacement != null) diagnostic("ORDER_DELIVERED stage=ranked uiVerified=false")
+        if (replacement != null) {
+            orderingHits.incrementAndGet()
+            diagnostic("ORDER_DELIVERED stage=ranked")
+        }
         result
     }
 
@@ -578,7 +580,8 @@ class ListCleanerModule : XposedModule() {
             val ordered = orderItems(list, kind, snapshot, "alpha", fixed, preset)
             if (ordered !== list) {
                 ordered.forEachIndexed { index, item -> list[index] = item }
-                diagnostic("ORDER_DELIVERED stage=alpha kind=$kind uiVerified=false")
+                orderingHits.incrementAndGet()
+                diagnostic("ORDER_DELIVERED stage=alpha kind=$kind")
             }
         }.onFailure { diagnostic("ORDER_FAILED stage=alpha error=${it.javaClass.name}") }
         chain.proceed()
@@ -635,9 +638,9 @@ class ListCleanerModule : XposedModule() {
                             uid = callerUid
                         }
                     }
-                    nonLocalizedLabel = "${BuildConfig.VERSION_CODE}:${applied.digest}"
+                    nonLocalizedLabel = "${BuildConfig.VERSION_CODE}:${applied.digest}:${queryHits.get()}:${visibilityHits.get()}:${orderingHits.get()}"
                 }
-                record("CONFIG_ACK version=${BuildConfig.VERSION_CODE} digest=${applied.digest} callerUid=$callerUid")
+                record("CONFIG_ACK version=${BuildConfig.VERSION_CODE} digest=${applied.digest} queryHits=${queryHits.get()} visibilityHits=${visibilityHits.get()} orderHits=${orderingHits.get()} callerUid=$callerUid")
                 return result.rebuild(listOf(ack))
             }
             return original
@@ -657,6 +660,7 @@ class ListCleanerModule : XposedModule() {
         val explicit = intent?.component != null || intent?.`package` != null ||
             outerIntent?.component != null || outerIntent?.`package` != null
         if (intent != null && kind != null) {
+            queryHits.incrementAndGet()
             val traceKey = "$layer|$kind|$callerUid"
             if (!explicit && (callerUid >= 10_000 || layer == Layer.RESOLVER) && snapshot.diagnostic &&
                 tracedActions.size < 128 && tracedActions.add(traceKey)) {
@@ -664,8 +668,8 @@ class ListCleanerModule : XposedModule() {
                     Throwable().stackTrace.take(14).joinToString(" <- ") { "${it.className}.${it.methodName}" })
             }
             diagnostic("QUERY layer=$layer kind=$kind action=${intent.action} mime=${intent.type ?: resolvedType} " +
-                "scheme=${intent.data?.scheme} file=${intent.data?.lastPathSegment} component=${intent.component?.flattenToShortString()} " +
-                "package=${intent.`package`} callerUid=$callerUid " +
+                "scheme=${intent.data?.scheme} ext=${safeExtension(intent.data?.lastPathSegment ?: intent.data?.path)} " +
+                "component=${intent.component?.flattenToShortString()} package=${intent.`package`} callerUid=$callerUid " +
                 "result=${original?.javaClass?.name} rules=${snapshot.configured.size} mode=${snapshot.displayMode}")
         }
         if (intent == null || explicit) {
@@ -689,6 +693,12 @@ class ListCleanerModule : XposedModule() {
             Log.e(TAG, "Failed to rebuild ${original?.javaClass?.name}; keeping original", it)
             original
         }
+    }
+
+    private fun safeExtension(fileNameOrPath: String?): String? {
+        val clean = fileNameOrPath?.substringBefore('?')?.substringBefore('#')?.substringAfterLast('/') ?: return null
+        val extension = clean.substringAfterLast('.', "").lowercase()
+        return extension.takeIf { it.length in 1..16 && it.all { ch -> ch.isLetterOrDigit() } }
     }
 
     private fun isSelectedCandidate(kind: IntentKind, activity: ActivityInfo, current: RuleSnapshot, layer: Layer): Boolean {
@@ -823,8 +833,7 @@ class ListCleanerModule : XposedModule() {
                     config.priorities, config.defaultOpen, config.openTypes, config.diagnostic, config.managerAppId, digest, config.hiddenFromApps)
                 lastEncodedConfig = encoded
                 record("MANAGER_IDENTITY appId=${config.managerAppId} source=remote_config")
-                record("RULES_READ reason=$reason count=${snapshot.configured.size} mode=${config.mode} diagnostic=${config.diagnostic} atomic=true priorities=${config.priorities.apps.mapValues { it.value.size }} typedRules=${config.openTypes.rules.mapValues { it.value.size }} typedPriorities=${config.openTypes.priorities.mapValues { it.value.size }} titles=${config.priorities.titles.size} legacyDefaultOpenIgnored=${config.defaultOpen.preferred.size} hiddenFromApps=${config.hiddenFromApps.size} visibilityTargets=${snapshot.allSelectedPackages.size} digest=$digest")
-                record("LEGACY_TILE_CONFIG ignored=true enabled=${config.tiles.enabled} hidden=${config.tiles.hidden.size}")
+                record("RULES_READ reason=$reason count=${snapshot.configured.size} mode=${config.mode} diagnostic=${config.diagnostic} atomic=true priorities=${config.priorities.apps.mapValues { it.value.size }} typedRules=${config.openTypes.rules.mapValues { it.value.size }} typedPriorities=${config.openTypes.priorities.mapValues { it.value.size }} titles=${config.priorities.titles.size} hiddenFromApps=${config.hiddenFromApps.size} visibilityOpenTargets=${snapshot.allSelectedPackages.size} digest=$digest")
                 return@runCatching
             }
             val rules = preferences.getStringSet(RuleRepository.KEY_RULES, emptySet()).orEmpty().toSet()
@@ -838,9 +847,6 @@ class ListCleanerModule : XposedModule() {
                     preferences.getString(RuleRepository.KEY_PRIORITIES, null) ?: "{}"
                 ).validated()
             }.getOrDefault(PriorityConfig())
-            val defaultOpen = runCatching {
-                Json.decodeFromString(DefaultOpenConfig.serializer(), preferences.getString(RuleRepository.KEY_DEFAULT_OPEN, null) ?: "{}").validated()
-            }.getOrDefault(DefaultOpenConfig())
             snapshot = RuleSnapshot(
                 configured = rules, displayMode = mode, priorities = priorities,
                 defaultOpen = DefaultOpenConfig(), openTypes = OpenTypeConfig(), diagnostic = preferences.getBoolean(RuleRepository.KEY_DIAGNOSTIC, false)

--- a/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
@@ -22,6 +22,7 @@ import com.yagay.ListCleaner.domain.PriorityConfig
 import com.yagay.ListCleaner.domain.DefaultOpenConfig
 import com.yagay.ListCleaner.domain.OpenTypeConfig
 import com.yagay.ListCleaner.domain.OpenPreset
+import com.yagay.ListCleaner.domain.VisibilityCompatConfig
 import com.yagay.ListCleaner.domain.matchOpenPreset
 import com.yagay.ListCleaner.domain.prioritizeApps
 import com.yagay.ListCleaner.domain.selectedKinds
@@ -57,7 +58,8 @@ class ListCleanerModule : XposedModule() {
         val diagnostic: Boolean,
         val managerAppId: Int = -1,
         val digest: String = "",
-        val hiddenFromApps: Set<String> = emptySet()
+        val hiddenFromApps: Set<String> = emptySet(),
+        val visibilityCompat: VisibilityCompatConfig = VisibilityCompatConfig()
     ) {
         val selectedKinds: Set<IntentKind> = selectedKinds(configured)
         private val selectedPackages: Map<IntentKind, Set<String>> = configured.mapNotNull { id ->
@@ -66,15 +68,7 @@ class ListCleanerModule : XposedModule() {
             val packageName = parts.getOrNull(1)?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
             kind to packageName
         }.groupBy({ it.first }, { it.second }).mapValues { (_, packages) -> packages.toSet() }
-        private val typedOpenPackages: Set<String> = openTypes.rules.values.asSequence().flatten().mapNotNull { id ->
-            val parts = id.split('|', limit = 3)
-            val kind = parts.getOrNull(0)?.let { runCatching { IntentKind.valueOf(it) }.getOrNull() }
-            if (kind != IntentKind.OPEN) return@mapNotNull null
-            parts.getOrNull(1)?.takeIf { it.isNotBlank() }
-        }.toSet()
-        // Compatibility hiding is intentionally limited to OPEN targets. A caller such as ES
-        // should not lose an app merely because that app is selected in SHARE or PROCESS_TEXT.
-        val allSelectedPackages: Set<String> = selectedPackages[IntentKind.OPEN].orEmpty() + typedOpenPackages
+        val allSelectedPackages: Set<String> = visibilityCompat.activePackages()
         fun hasSelection(kind: IntentKind): Boolean = kind in selectedKinds
         fun hasPackageSelection(kind: IntentKind, packageName: String): Boolean = packageName in selectedPackages[kind].orEmpty()
     }
@@ -295,7 +289,7 @@ class ListCleanerModule : XposedModule() {
                 }
             }
         }
-        record("VISIBILITY_HOOKS new=$installed callers=${snapshot.hiddenFromApps.size} targets=${snapshot.allSelectedPackages.size}")
+        record("VISIBILITY_HOOKS new=$installed callers=${snapshot.hiddenFromApps.size} scopes=${snapshot.visibilityCompat.scopes.map { it.name }.sorted()} targets=${snapshot.allSelectedPackages.size}")
     }
 
     private fun visibilityAdapter(method: Method): VisibilityLayout? =
@@ -324,7 +318,7 @@ class ListCleanerModule : XposedModule() {
         }
 
         visibilityHits.incrementAndGet()
-        diagnostic("SYSTEM_VISIBILITY_FILTER uid=$callingUid caller=${callers.sorted()} target=$target")
+        diagnostic("SYSTEM_VISIBILITY_FILTER uid=$callingUid caller=${callers.sorted()} target=$target scopes=${current.visibilityCompat.scopes.map { it.name }.sorted()}")
         true
     }
 
@@ -830,10 +824,11 @@ class ListCleanerModule : XposedModule() {
                 if (snapshot.digest == digest) return@runCatching
                 val config = Json { ignoreUnknownKeys = true }.decodeFromString(ModuleConfig.serializer(), encoded).validated()
                 snapshot = RuleSnapshot(config.rules.map { it.id }.toSet(), config.mode,
-                    config.priorities, config.defaultOpen, config.openTypes, config.diagnostic, config.managerAppId, digest, config.hiddenFromApps)
+                    config.priorities, config.defaultOpen, config.openTypes, config.diagnostic, config.managerAppId, digest,
+                    config.hiddenFromApps, config.visibilityCompat)
                 lastEncodedConfig = encoded
                 record("MANAGER_IDENTITY appId=${config.managerAppId} source=remote_config")
-                record("RULES_READ reason=$reason count=${snapshot.configured.size} mode=${config.mode} diagnostic=${config.diagnostic} atomic=true priorities=${config.priorities.apps.mapValues { it.value.size }} typedRules=${config.openTypes.rules.mapValues { it.value.size }} typedPriorities=${config.openTypes.priorities.mapValues { it.value.size }} titles=${config.priorities.titles.size} hiddenFromApps=${config.hiddenFromApps.size} visibilityOpenTargets=${snapshot.allSelectedPackages.size} digest=$digest")
+                record("RULES_READ reason=$reason count=${snapshot.configured.size} mode=${config.mode} diagnostic=${config.diagnostic} atomic=true priorities=${config.priorities.apps.mapValues { it.value.size }} typedRules=${config.openTypes.rules.mapValues { it.value.size }} typedPriorities=${config.openTypes.priorities.mapValues { it.value.size }} titles=${config.priorities.titles.size} hiddenFromApps=${config.hiddenFromApps.size} visibilityScopes=${config.visibilityCompat.scopes.map { it.name }.sorted()} visibilityTargets=${snapshot.allSelectedPackages.size} digest=$digest")
                 return@runCatching
             }
             val rules = preferences.getStringSet(RuleRepository.KEY_RULES, emptySet()).orEmpty().toSet()

--- a/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
@@ -20,6 +20,10 @@ import com.yagay.ListCleaner.data.RuleRepository
 import com.yagay.ListCleaner.domain.DisplayMode
 import com.yagay.ListCleaner.domain.IntentKind
 import com.yagay.ListCleaner.domain.PriorityConfig
+import com.yagay.ListCleaner.domain.DefaultOpenConfig
+import com.yagay.ListCleaner.domain.OpenTypeConfig
+import com.yagay.ListCleaner.domain.OpenPreset
+import com.yagay.ListCleaner.domain.matchOpenPreset
 import com.yagay.ListCleaner.domain.prioritizeApps
 import com.yagay.ListCleaner.domain.selectedKinds
 import io.github.libxposed.api.XposedInterface
@@ -48,6 +52,8 @@ class ListCleanerModule : XposedModule() {
         val configured: Set<String>,
         val displayMode: DisplayMode,
         val priorities: PriorityConfig,
+        val defaultOpen: DefaultOpenConfig,
+        val openTypes: OpenTypeConfig,
         val diagnostic: Boolean,
         val managerAppId: Int = -1,
         val digest: String = "",
@@ -68,7 +74,7 @@ class ListCleanerModule : XposedModule() {
     private data class ListResult(val values: List<*>, val rebuild: (List<*>) -> Any?)
 
     @Volatile
-    private var snapshot = RuleSnapshot(emptySet(), DisplayMode.HIDE_SELECTED, PriorityConfig(), false)
+    private var snapshot = RuleSnapshot(emptySet(), DisplayMode.HIDE_SELECTED, PriorityConfig(), DefaultOpenConfig(), OpenTypeConfig(), false)
     private var lastEncodedConfig: String? = null
     @Volatile
     private var listenerRegistered = false
@@ -468,9 +474,23 @@ class ListCleanerModule : XposedModule() {
         return intent.intentKind(mime)
     }
 
+    private fun adapterOpenPreset(receiver: Any, kind: IntentKind): OpenPreset? {
+        if (kind != IntentKind.OPEN) return null
+        val intent = OrderingAccess.targetIntent(receiver) as? Intent ?: return null
+        val effective = intent.selector ?: intent
+        val context = runCatching { OrderingAccess.field(receiver, "mContext") as? Context }.getOrNull()
+        val mime = effective.type ?: runCatching { context?.let { effective.resolveTypeIfNeeded(it.contentResolver) } }.getOrNull()
+        return matchOpenPreset(kind, mime, effective.data?.scheme)
+    }
+
+    private fun effectivePriorities(kind: IntentKind, preset: OpenPreset?, current: RuleSnapshot): List<String> {
+        val typed = if (kind == IntentKind.OPEN && preset != null) current.openTypes.priorities[preset].orEmpty() else emptyList()
+        return if (typed.isNotEmpty()) typed else current.priorities.apps[kind].orEmpty()
+    }
+
     private fun orderItems(items: List<*>, kind: IntentKind, current: RuleSnapshot, stage: String,
-        fixedPackages: Set<String> = emptySet()): List<*> {
-        val priorities = current.priorities.apps[kind].orEmpty()
+        fixedPackages: Set<String> = emptySet(), preset: OpenPreset? = null): List<*> {
+        val priorities = effectivePriorities(kind, preset, current)
         if (priorities.isEmpty() || items.size < 2) return items
         val infos = items.map { item ->
             requireNotNull(item)
@@ -503,13 +523,14 @@ class ListCleanerModule : XposedModule() {
                 diagnostic("ORDER_SKIP reason=unclassified_intent")
                 return@runCatching null
             }
-            val priorities = current.priorities.apps[kind].orEmpty()
+            val preset = adapterOpenPreset(receiver, kind)
+            val priorities = effectivePriorities(kind, preset, current)
             if (priorities.isEmpty()) {
                 diagnostic("ORDER_SKIP kind=$kind reason=no_priorities")
                 return@runCatching null
             }
             val items = chain.args[0] as? List<*> ?: return@runCatching null
-            val ordered = orderItems(items, kind, current, "ranked")
+            val ordered = orderItems(items, kind, current, "ranked", preset = preset)
             if (ordered === items) null else chain.args.toTypedArray().also { it[0] = ordered }
         }.getOrElse {
             diagnostic("ORDER_FAILED error=${it.javaClass.name}")
@@ -533,6 +554,7 @@ class ListCleanerModule : XposedModule() {
                 return@runCatching
             }
             val kind = adapterKind(receiver) ?: return@runCatching
+            val preset = adapterOpenPreset(receiver, kind)
             val items = OrderingAccess.field(receiver, "mSortedList")
             if (items == null || items.javaClass != java.util.ArrayList::class.java) {
                 diagnostic("ORDER_SKIP stage=alpha reason=unsupported_backing_list")
@@ -545,7 +567,7 @@ class ListCleanerModule : XposedModule() {
                 val info = OrderingAccess.call(requireNotNull(target), "getResolveInfo") as ResolveInfo
                 info.activityInfo.packageName
             }.toSet()
-            val ordered = orderItems(list, kind, snapshot, "alpha", fixed)
+            val ordered = orderItems(list, kind, snapshot, "alpha", fixed, preset)
             if (ordered !== list) {
                 ordered.forEachIndexed { index, item -> list[index] = item }
                 diagnostic("ORDER_DELIVERED stage=alpha kind=$kind uiVerified=false")
@@ -650,7 +672,7 @@ class ListCleanerModule : XposedModule() {
             diagnostic("skip $layer ${intent.action}: unsupported result ${original?.javaClass?.name}")
             return original
         }
-        val replacement = transform(kind, extracted.values, layer, callerUid) ?: return original
+        val replacement = transform(kind, extracted.values, layer, callerUid, intent.type ?: resolvedType, intent.data?.scheme) ?: return original
         return runCatching { extracted.rebuild(replacement) }.getOrElse {
             Log.e(TAG, "Failed to rebuild ${original?.javaClass?.name}; keeping original", it)
             original
@@ -666,7 +688,7 @@ class ListCleanerModule : XposedModule() {
         return false
     }
 
-    private fun transform(kind: IntentKind, values: List<*>, layer: Layer, callerUid: Int): List<*>? {
+    private fun transform(kind: IntentKind, values: List<*>, layer: Layer, callerUid: Int, mimeType: String?, scheme: String?): List<*>? {
         if (values.isEmpty()) { diagnostic("SKIP $layer $kind empty_input"); return null }
         val current = snapshot
         if (current.displayMode == DisplayMode.SHOW_ALL) {
@@ -674,7 +696,10 @@ class ListCleanerModule : XposedModule() {
             return null
         }
         var changed = false
-        val filtered = if (!current.hasSelection(kind) && current.displayMode != DisplayMode.SHOW_SELECTED) {
+        val preset = matchOpenPreset(kind, mimeType, scheme)
+        val typedIds = if (kind == IntentKind.OPEN && preset != null) current.openTypes.rules[preset].orEmpty() else emptySet()
+        val hasSelection = current.hasSelection(kind) || typedIds.isNotEmpty()
+        val filtered = if (!hasSelection && current.displayMode != DisplayMode.SHOW_SELECTED) {
             values
         } else {
             values.filter { value ->
@@ -687,12 +712,13 @@ class ListCleanerModule : XposedModule() {
                 val canonicalClass = com.yagay.ListCleaner.domain.ComponentIdentity.canonicalClassName(
                     activity.packageName, activity.name, activity.targetActivity
                 )
-                val selected = "${kind.name}|${activity.packageName}|$canonicalClass" in current.configured
+                val candidateId = "${kind.name}|${activity.packageName}|$canonicalClass"
+                val selected = candidateId in current.configured || candidateId in typedIds
                 diagnostic(
                     "CANDIDATE $layer $kind ${activity.packageName}/${activity.name} target=${activity.targetActivity} canonical=$canonicalClass selected=$selected match=${if (selected) "component" else "none"}",
                     detail = true
                 )
-                current.displayMode.includes(selected, current.hasSelection(kind)).also {
+                current.displayMode.includes(selected, hasSelection).also {
                     if (!it) changed = true
                 }
             }
@@ -703,7 +729,7 @@ class ListCleanerModule : XposedModule() {
             return null
         }
         val ordered = if (kind == IntentKind.PROCESS_TEXT) runCatching {
-            orderItems(filtered, kind, current, "text_query")
+            orderItems(filtered, kind, current, "text_query", preset = preset)
         }.getOrElse {
             diagnostic("ORDER_FAILED stage=text_query error=${it.javaClass.name}")
             filtered
@@ -715,7 +741,7 @@ class ListCleanerModule : XposedModule() {
         }
         if (titleCount > 0) changed = true
         if (!changed) {
-            diagnostic("NO_CHANGE $layer $kind size=${values.size} hasSelection=${current.hasSelection(kind)}")
+            diagnostic("NO_CHANGE $layer $kind size=${values.size} hasSelection=$hasSelection preset=$preset")
             return null
         }
         diagnostic("$layer $kind: ${values.size} -> ${titled.size}")
@@ -775,10 +801,10 @@ class ListCleanerModule : XposedModule() {
                 if (snapshot.digest == digest) return@runCatching
                 val config = Json { ignoreUnknownKeys = true }.decodeFromString(ModuleConfig.serializer(), encoded).validated()
                 snapshot = RuleSnapshot(config.rules.map { it.id }.toSet(), config.mode,
-                    config.priorities, config.diagnostic, config.managerAppId, digest, config.hiddenFromApps)
+                    config.priorities, config.defaultOpen, config.openTypes, config.diagnostic, config.managerAppId, digest, config.hiddenFromApps)
                 lastEncodedConfig = encoded
                 record("MANAGER_IDENTITY appId=${config.managerAppId} source=remote_config")
-                record("RULES_READ reason=$reason count=${snapshot.configured.size} mode=${config.mode} diagnostic=${config.diagnostic} atomic=true priorities=${config.priorities.apps.mapValues { it.value.size }} titles=${config.priorities.titles.size} hiddenFromApps=${config.hiddenFromApps.size} digest=$digest")
+                record("RULES_READ reason=$reason count=${snapshot.configured.size} mode=${config.mode} diagnostic=${config.diagnostic} atomic=true priorities=${config.priorities.apps.mapValues { it.value.size }} typedRules=${config.openTypes.rules.mapValues { it.value.size }} typedPriorities=${config.openTypes.priorities.mapValues { it.value.size }} titles=${config.priorities.titles.size} legacyDefaultOpenIgnored=${config.defaultOpen.preferred.size} hiddenFromApps=${config.hiddenFromApps.size} digest=$digest")
                 record("LEGACY_TILE_CONFIG ignored=true enabled=${config.tiles.enabled} hidden=${config.tiles.hidden.size}")
                 return@runCatching
             }
@@ -793,9 +819,12 @@ class ListCleanerModule : XposedModule() {
                     preferences.getString(RuleRepository.KEY_PRIORITIES, null) ?: "{}"
                 ).validated()
             }.getOrDefault(PriorityConfig())
+            val defaultOpen = runCatching {
+                Json.decodeFromString(DefaultOpenConfig.serializer(), preferences.getString(RuleRepository.KEY_DEFAULT_OPEN, null) ?: "{}").validated()
+            }.getOrDefault(DefaultOpenConfig())
             snapshot = RuleSnapshot(
                 configured = rules, displayMode = mode, priorities = priorities,
-                diagnostic = preferences.getBoolean(RuleRepository.KEY_DIAGNOSTIC, false)
+                defaultOpen = DefaultOpenConfig(), openTypes = OpenTypeConfig(), diagnostic = preferences.getBoolean(RuleRepository.KEY_DIAGNOSTIC, false)
             )
             lastEncodedConfig = null
             record("RULES_READ reason=$reason count=${rules.size} mode=$mode diagnostic=${snapshot.diagnostic}")

--- a/app/src/test/java/com/yagay/ListCleaner/domain/DefaultOpenConfigTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/DefaultOpenConfigTest.kt
@@ -53,6 +53,35 @@ class DefaultOpenConfigTest {
         assertEquals(OpenPreset.TEXT, matchOpenPreset(IntentKind.OPEN, "text/plain", "content", "looks-like.pdf"))
     }
 
+    @Test fun customMimeAndExtensionAreClassified() {
+        val definitions = mapOf(
+            OpenPreset.CUSTOM_1 to CustomOpenDefinition(
+                title = "Kindle",
+                mimeTypes = setOf("application/vnd.amazon.ebook"),
+                extensions = setOf("azw3", "mobi")
+            ).validated(),
+            OpenPreset.CUSTOM_2 to CustomOpenDefinition(
+                title = "Playlist",
+                mimeTypes = setOf("application/vnd.apple.mpegurl"),
+                extensions = setOf("m3u8")
+            ).validated()
+        )
+        assertEquals(OpenPreset.CUSTOM_1,
+            matchOpenPreset(IntentKind.OPEN, "application/vnd.amazon.ebook", "content", "book.bin", definitions))
+        assertEquals(OpenPreset.CUSTOM_1,
+            matchOpenPreset(IntentKind.OPEN, "application/octet-stream", "content", "book.AZW3", definitions))
+        assertEquals(OpenPreset.CUSTOM_2,
+            matchOpenPreset(IntentKind.OPEN, null, "content", "stream.m3u8?token=1", definitions))
+    }
+
+    @Test fun customWildcardMimeCanMatchSubtypeFamily() {
+        val definitions = mapOf(
+            OpenPreset.CUSTOM_1 to CustomOpenDefinition("Custom image", setOf("image/*"), emptySet()).validated()
+        )
+        assertEquals(OpenPreset.CUSTOM_1,
+            matchOpenPreset(IntentKind.OPEN, "image/heic", "content", null, definitions))
+    }
+
     @Test fun configRequiresMatchingKindAndCanonicalId() {
         val open = ComponentRule(IntentKind.OPEN, "com.example", "com.example.Reader")
         DefaultOpenConfig(mapOf(OpenPreset.PDF to open.id, OpenPreset.MAGNET to open.id)).validated()

--- a/app/src/test/java/com/yagay/ListCleaner/domain/DefaultOpenConfigTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/DefaultOpenConfigTest.kt
@@ -40,6 +40,19 @@ class DefaultOpenConfigTest {
         assertEquals(OpenPreset.CSV, matchOpenPreset(IntentKind.OPEN, "application/csv", "content"))
     }
 
+    @Test fun opaqueMimeFallsBackToFileExtension() {
+        assertEquals(OpenPreset.PDF, matchOpenPreset(IntentKind.OPEN, "*/*", "content", "/storage/emulated/0/Download/book.PDF"))
+        assertEquals(OpenPreset.APK, matchOpenPreset(IntentKind.OPEN, "application/octet-stream", "content", "release.apk"))
+        assertEquals(OpenPreset.ARCHIVE, matchOpenPreset(IntentKind.OPEN, "binary/octet-stream", "file", "backup.7z"))
+        assertEquals(OpenPreset.WORD, matchOpenPreset(IntentKind.OPEN, null, "content", "document.docx"))
+        assertEquals(OpenPreset.IMAGE, matchOpenPreset(IntentKind.OPEN, "application/x-download", "content", "photo.webp?token=1"))
+    }
+
+    @Test fun specificUnknownMimeDoesNotGetOverriddenByExtension() {
+        assertNull(matchOpenPreset(IntentKind.OPEN, "application/vnd.example.custom", "content", "looks-like.pdf"))
+        assertEquals(OpenPreset.TEXT, matchOpenPreset(IntentKind.OPEN, "text/plain", "content", "looks-like.pdf"))
+    }
+
     @Test fun configRequiresMatchingKindAndCanonicalId() {
         val open = ComponentRule(IntentKind.OPEN, "com.example", "com.example.Reader")
         DefaultOpenConfig(mapOf(OpenPreset.PDF to open.id, OpenPreset.MAGNET to open.id)).validated()

--- a/app/src/test/java/com/yagay/ListCleaner/domain/DefaultOpenConfigTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/DefaultOpenConfigTest.kt
@@ -1,0 +1,50 @@
+package com.yagay.ListCleaner.domain
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class DefaultOpenConfigTest {
+    @Test fun mimePresetsAreClassified() {
+        assertEquals(OpenPreset.PDF, matchOpenPreset(IntentKind.OPEN, "application/pdf", "content"))
+        assertEquals(OpenPreset.WORD, matchOpenPreset(IntentKind.OPEN, "application/vnd.openxmlformats-officedocument.wordprocessingml.document", "content"))
+        assertEquals(OpenPreset.EXCEL, matchOpenPreset(IntentKind.OPEN, "application/vnd.ms-excel", "content"))
+        assertEquals(OpenPreset.POWERPOINT, matchOpenPreset(IntentKind.OPEN, "application/vnd.ms-powerpoint", "content"))
+        assertEquals(OpenPreset.EPUB, matchOpenPreset(IntentKind.OPEN, "application/epub+zip", "content"))
+        assertEquals(OpenPreset.APK, matchOpenPreset(IntentKind.OPEN, "application/vnd.android.package-archive", "content"))
+        assertEquals(OpenPreset.TORRENT, matchOpenPreset(IntentKind.OPEN, "application/x-bittorrent", "content"))
+        assertEquals(OpenPreset.MARKDOWN, matchOpenPreset(IntentKind.OPEN, "text/markdown", "content"))
+        assertEquals(OpenPreset.CSV, matchOpenPreset(IntentKind.OPEN, "text/csv", "content"))
+        assertEquals(OpenPreset.JSON, matchOpenPreset(IntentKind.OPEN, "application/problem+json", "content"))
+        assertEquals(OpenPreset.XML, matchOpenPreset(IntentKind.OPEN, "application/atom+xml", "content"))
+        assertEquals(OpenPreset.SVG, matchOpenPreset(IntentKind.OPEN, "image/svg+xml", "content"))
+        assertEquals(OpenPreset.GIF, matchOpenPreset(IntentKind.OPEN, "image/gif", "content"))
+        assertEquals(OpenPreset.IMAGE, matchOpenPreset(IntentKind.OPEN, "image/png", "content"))
+        assertEquals(OpenPreset.ARCHIVE, matchOpenPreset(IntentKind.OPEN, "application/zip", "content"))
+        assertEquals(OpenPreset.BROWSER, matchOpenPreset(IntentKind.BROWSER, null, "https"))
+        assertNull(matchOpenPreset(IntentKind.OPEN, "application/octet-stream", "content"))
+    }
+
+    @Test fun schemePresetsAreClassified() {
+        assertEquals(OpenPreset.MAGNET, matchOpenPreset(IntentKind.OPEN, null, "magnet"))
+        assertEquals(OpenPreset.GEO, matchOpenPreset(IntentKind.OPEN, null, "geo"))
+        assertEquals(OpenPreset.MAILTO, matchOpenPreset(IntentKind.OPEN, null, "mailto"))
+        assertEquals(OpenPreset.TEL, matchOpenPreset(IntentKind.OPEN, null, "tel"))
+        assertEquals(OpenPreset.SMS, matchOpenPreset(IntentKind.OPEN, null, "sms"))
+        assertEquals(OpenPreset.SMS, matchOpenPreset(IntentKind.OPEN, null, "smsto"))
+    }
+
+    @Test fun specificImageAndTextTypesBeatBroadCategories() {
+        assertEquals(OpenPreset.SVG, matchOpenPreset(IntentKind.OPEN, "image/svg+xml", "content"))
+        assertEquals(OpenPreset.GIF, matchOpenPreset(IntentKind.OPEN, "image/gif", "content"))
+        assertEquals(OpenPreset.MARKDOWN, matchOpenPreset(IntentKind.OPEN, "text/x-markdown", "content"))
+        assertEquals(OpenPreset.CSV, matchOpenPreset(IntentKind.OPEN, "application/csv", "content"))
+    }
+
+    @Test fun configRequiresMatchingKindAndCanonicalId() {
+        val open = ComponentRule(IntentKind.OPEN, "com.example", "com.example.Reader")
+        DefaultOpenConfig(mapOf(OpenPreset.PDF to open.id, OpenPreset.MAGNET to open.id)).validated()
+        assertThrows(IllegalArgumentException::class.java) {
+            DefaultOpenConfig(mapOf(OpenPreset.BROWSER to open.id)).validated()
+        }
+    }
+}

--- a/app/src/test/java/com/yagay/ListCleaner/domain/ModuleConfigTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/ModuleConfigTest.kt
@@ -6,16 +6,43 @@ import org.junit.Test
 
 class ModuleConfigTest {
     @Test fun hiddenFromAppsRoundTrip() {
-        val config = ModuleConfig(emptySet(), DisplayMode.HIDE_SELECTED, PriorityConfig(), false, 10715, TileConfig(), setOf("com.estrongs.android.pop"))
+        val config = ModuleConfig(
+            emptySet(), DisplayMode.HIDE_SELECTED, PriorityConfig(), false, 10715,
+            hiddenFromApps = setOf("com.estrongs.android.pop")
+        )
         val encoded = Json.encodeToString(ModuleConfig.serializer(), config)
         assertEquals(config, Json.decodeFromString(ModuleConfig.serializer(), encoded).validated())
     }
 
     @Test fun atomicConfigurationRoundTrip() {
-        val config = ModuleConfig(setOf(ComponentRule(IntentKind.OPEN, "com.example", "com.example.Open")),
-            DisplayMode.SHOW_SELECTED, PriorityConfig(mapOf(IntentKind.OPEN to listOf("com.example"))), true, 10715)
+        val config = ModuleConfig(
+            setOf(ComponentRule(IntentKind.OPEN, "com.example", "com.example.Open")),
+            DisplayMode.SHOW_SELECTED,
+            PriorityConfig(mapOf(IntentKind.OPEN to listOf("com.example"))),
+            true,
+            10715
+        )
         assertEquals(config, Json.decodeFromString(ModuleConfig.serializer(),
             Json.encodeToString(ModuleConfig.serializer(), config)).validated())
+    }
+
+    @Test fun legacyRuntimeFieldsAreNotSerialized() {
+        val config = ModuleConfig(
+            emptySet(), DisplayMode.HIDE_SELECTED, PriorityConfig(), false,
+            tiles = TileConfig(enabled = true, hidden = setOf("pkg/.Tile")),
+            defaultOpen = DefaultOpenConfig(mapOf(
+                OpenPreset.PDF to ComponentRule(IntentKind.OPEN, "com.example", "com.example.Reader").id
+            ))
+        )
+        val encoded = Json.encodeToString(ModuleConfig.serializer(), config)
+        assertFalse(encoded.contains("tiles"))
+        assertFalse(encoded.contains("defaultOpen"))
+        val decoded = Json { ignoreUnknownKeys = true }.decodeFromString(
+            ModuleConfig.serializer(),
+            encoded.dropLast(1) + ",\"tiles\":{\"enabled\":true,\"hidden\":[]},\"defaultOpen\":{\"preferred\":{}}}"
+        )
+        assertEquals(TileConfig(), decoded.tiles)
+        assertEquals(DefaultOpenConfig(), decoded.defaultOpen)
     }
 
     @Test fun relativeNamesMatchExpandedRuleIds() {

--- a/app/src/test/java/com/yagay/ListCleaner/domain/OpenEffectPreviewTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/OpenEffectPreviewTest.kt
@@ -1,0 +1,44 @@
+package com.yagay.ListCleaner.domain
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OpenEffectPreviewTest {
+    private val a = ComponentCandidate(ComponentRule(IntentKind.OPEN, "a.app", "a.app.Open"), "A", "Open")
+    private val b = ComponentCandidate(ComponentRule(IntentKind.OPEN, "b.app", "b.app.Open"), "B", "Open")
+    private val c = ComponentCandidate(ComponentRule(IntentKind.OPEN, "c.app", "c.app.Open"), "C", "Open")
+
+    @Test fun genericAndTypedRulesAreBothShownWithSources() {
+        val config = OpenTypeConfig(rules = mapOf(OpenPreset.PDF to setOf(b.rule.id)))
+        val preview = previewOpenEffect(
+            listOf(a, b, c), setOf(a.rule), DisplayMode.HIDE_SELECTED, PriorityConfig(), config,
+            "application/pdf", "content", "book.pdf"
+        )
+        assertEquals(OpenPreset.PDF, preview.preset)
+        assertEquals(1, preview.finalCount)
+        assertEquals("全部", preview.items.first { it.candidate.rule == a.rule }.selectedBy)
+        assertEquals("PDF", preview.items.first { it.candidate.rule == b.rule }.selectedBy)
+        assertFalse(preview.items.first { it.candidate.rule == a.rule }.included)
+        assertTrue(preview.items.first { it.candidate.rule == c.rule }.included)
+    }
+
+    @Test fun typedPriorityOverridesGenericAndEmptyTypedInheritsGeneric() {
+        val inherited = previewOpenEffect(
+            listOf(a, b, c), emptySet(), DisplayMode.HIDE_SELECTED,
+            PriorityConfig(apps = mapOf(IntentKind.OPEN to listOf("c.app", "a.app"))),
+            OpenTypeConfig(), "application/pdf", "content", "book.pdf"
+        )
+        assertEquals(1, inherited.items.first { it.candidate.rule == c.rule }.rank)
+
+        val explicit = previewOpenEffect(
+            listOf(a, b, c), emptySet(), DisplayMode.HIDE_SELECTED,
+            PriorityConfig(apps = mapOf(IntentKind.OPEN to listOf("c.app", "a.app"))),
+            OpenTypeConfig(priorities = mapOf(OpenPreset.PDF to listOf("b.app"))),
+            "application/pdf", "content", "book.pdf"
+        )
+        assertEquals(1, explicit.items.first { it.candidate.rule == b.rule }.rank)
+        assertEquals(null, explicit.items.first { it.candidate.rule == c.rule }.rank)
+    }
+}

--- a/app/src/test/java/com/yagay/ListCleaner/domain/OpenTypeConfigTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/OpenTypeConfigTest.kt
@@ -1,0 +1,14 @@
+package com.yagay.ListCleaner.domain
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class OpenTypeConfigTest {
+    @Test fun typedConfigRequiresOpenComponents() {
+        val open = ComponentRule(IntentKind.OPEN, "com.example", "com.example.Reader")
+        OpenTypeConfig(rules = mapOf(OpenPreset.PDF to setOf(open.id)), priorities = mapOf(OpenPreset.PDF to listOf("com.example"))).validated()
+        assertThrows(IllegalArgumentException::class.java) {
+            OpenTypeConfig(rules = mapOf(OpenPreset.PDF to setOf(ComponentRule(IntentKind.SHARE, "com.example", "com.example.Share").id))).validated()
+        }
+    }
+}

--- a/app/src/test/java/com/yagay/ListCleaner/domain/OpenTypeConfigTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/OpenTypeConfigTest.kt
@@ -6,9 +6,46 @@ import org.junit.Test
 class OpenTypeConfigTest {
     @Test fun typedConfigRequiresOpenComponents() {
         val open = ComponentRule(IntentKind.OPEN, "com.example", "com.example.Reader")
-        OpenTypeConfig(rules = mapOf(OpenPreset.PDF to setOf(open.id)), priorities = mapOf(OpenPreset.PDF to listOf("com.example"))).validated()
+        OpenTypeConfig(
+            rules = mapOf(OpenPreset.PDF to setOf(open.id)),
+            priorities = mapOf(OpenPreset.PDF to listOf("com.example"))
+        ).validated()
         assertThrows(IllegalArgumentException::class.java) {
-            OpenTypeConfig(rules = mapOf(OpenPreset.PDF to setOf(ComponentRule(IntentKind.SHARE, "com.example", "com.example.Share").id))).validated()
+            OpenTypeConfig(
+                rules = mapOf(OpenPreset.PDF to setOf(ComponentRule(IntentKind.SHARE, "com.example", "com.example.Share").id))
+            ).validated()
         }
+    }
+
+    @Test fun customRuleRequiresDefinition() {
+        val open = ComponentRule(IntentKind.OPEN, "com.example", "com.example.Reader")
+        assertThrows(IllegalArgumentException::class.java) {
+            OpenTypeConfig(rules = mapOf(OpenPreset.CUSTOM_1 to setOf(open.id))).validated()
+        }
+        val config = OpenTypeConfig(
+            rules = mapOf(OpenPreset.CUSTOM_1 to setOf(open.id)),
+            customDefinitions = mapOf(
+                OpenPreset.CUSTOM_1 to CustomOpenDefinition("Kindle", extensions = setOf("azw3"))
+            )
+        ).validated()
+        assertEquals("Kindle", config.titleFor(OpenPreset.CUSTOM_1))
+        assertTrue(OpenPreset.CUSTOM_1 in config.configuredPresets())
+        assertFalse(OpenPreset.CUSTOM_2 in config.configuredPresets())
+    }
+
+    @Test fun customDefinitionIsNormalized() {
+        val config = OpenTypeConfig(
+            customDefinitions = mapOf(
+                OpenPreset.CUSTOM_1 to CustomOpenDefinition(
+                    "  Playlist  ",
+                    mimeTypes = setOf("APPLICATION/VND.APPLE.MPEGURL"),
+                    extensions = setOf(".M3U8")
+                )
+            )
+        ).validated()
+        val definition = requireNotNull(config.customDefinitions[OpenPreset.CUSTOM_1])
+        assertEquals("Playlist", definition.title)
+        assertEquals(setOf("application/vnd.apple.mpegurl"), definition.mimeTypes)
+        assertEquals(setOf("m3u8"), definition.extensions)
     }
 }

--- a/app/src/test/java/com/yagay/ListCleaner/domain/TileConfigTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/TileConfigTest.kt
@@ -9,13 +9,34 @@ class TileConfigTest {
         val old = """{"rules":[],"mode":"HIDE_SELECTED","priorities":{},"diagnostic":false}"""
         assertEquals(TileConfig(), Json.decodeFromString(ModuleConfig.serializer(), old).validated().tiles)
     }
-    @Test fun tileSettingsRoundTripWithRulesAndBackup() {
+
+    @Test fun legacyTileSettingsAreNoLongerPersisted() {
         val tiles = TileConfig(true, setOf("wifi", "custom(com.example/com.example.Tile)"))
-        val config = ModuleConfig(emptySet(), DisplayMode.HIDE_SELECTED, PriorityConfig(), false, 10715, tiles)
-        assertEquals(config, Json.decodeFromString(ModuleConfig.serializer(), Json.encodeToString(ModuleConfig.serializer(), config)).validated())
-        val backup = RuleBackup(version = 4, blacklist = true, rules = emptySet(), displayMode = DisplayMode.HIDE_SELECTED, tiles = tiles)
-        assertEquals(backup, Json.decodeFromString(RuleBackup.serializer(), Json.encodeToString(RuleBackup.serializer(), backup)))
+        val config = ModuleConfig(
+            emptySet(), DisplayMode.HIDE_SELECTED, PriorityConfig(), false, 10715, tiles
+        )
+        val encodedConfig = Json.encodeToString(ModuleConfig.serializer(), config)
+        assertFalse(encodedConfig.contains("tiles"))
+        assertEquals(
+            TileConfig(),
+            Json { ignoreUnknownKeys = true }.decodeFromString(ModuleConfig.serializer(), encodedConfig).validated().tiles
+        )
+
+        val backup = RuleBackup(
+            version = 4,
+            blacklist = true,
+            rules = emptySet(),
+            displayMode = DisplayMode.HIDE_SELECTED,
+            tiles = tiles
+        )
+        val encodedBackup = Json.encodeToString(RuleBackup.serializer(), backup)
+        assertFalse(encodedBackup.contains("tiles"))
+        assertEquals(
+            TileConfig(),
+            Json { ignoreUnknownKeys = true }.decodeFromString(RuleBackup.serializer(), encodedBackup).tiles
+        )
     }
+
     @Test fun malformedAndUnboundedRulesAreRejected() {
         assertThrows(IllegalArgumentException::class.java) { TileConfig(true, setOf("bad\nvalue")).validated() }
         assertThrows(IllegalArgumentException::class.java) { TileConfig(true, setOf("custom(com.example/.Tile)")).validated() }

--- a/app/src/test/java/com/yagay/ListCleaner/domain/VisibilityCompatTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/VisibilityCompatTest.kt
@@ -1,0 +1,49 @@
+package com.yagay.ListCleaner.domain
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class VisibilityCompatTest {
+    private fun candidate(kind: IntentKind, pkg: String, cls: String) =
+        ComponentCandidate(ComponentRule(kind, pkg, "$pkg.$cls"), pkg, cls)
+
+    @Test fun partialAppSelectionNeverBecomesVisibilityTarget() {
+        val a = candidate(IntentKind.SHARE, "com.example.a", "ShareOne")
+        val b = candidate(IntentKind.SHARE, "com.example.a", "ShareTwo")
+        val other = candidate(IntentKind.SHARE, "com.example.b", "Share")
+
+        val partial = deriveFullySelectedPackages(listOf(a, b, other), setOf(a.rule, other.rule))
+        assertFalse("half-selected app must not be hidden package-wide",
+            "com.example.a" in partial[VisibilityScope.SHARE].orEmpty())
+        assertTrue("fully selected one-component app should qualify",
+            "com.example.b" in partial[VisibilityScope.SHARE].orEmpty())
+
+        val full = deriveFullySelectedPackages(listOf(a, b, other), setOf(a.rule, b.rule, other.rule))
+        assertTrue("com.example.a" in full[VisibilityScope.SHARE].orEmpty())
+    }
+
+    @Test fun selectedScopesAreUnionAndDefaultIsDisabled() {
+        val packages = mapOf(
+            VisibilityScope.SHARE to setOf("com.share"),
+            VisibilityScope.BROWSER to setOf("com.browser"),
+            VisibilityScope.OPEN to setOf("com.open")
+        )
+        assertTrue(VisibilityCompatConfig(fullPackages = packages).activePackages().isEmpty())
+        assertEquals(
+            setOf("com.share", "com.browser"),
+            VisibilityCompatConfig(setOf(VisibilityScope.SHARE, VisibilityScope.BROWSER), packages).activePackages()
+        )
+        assertEquals(
+            setOf("com.share", "com.browser", "com.open"),
+            VisibilityCompatConfig(setOf(VisibilityScope.ALL), packages).activePackages()
+        )
+    }
+
+    @Test fun unavailableOrRestrictedCandidatesDoNotCreateHalfState() {
+        val visible = candidate(IntentKind.BROWSER, "com.example", "Browser")
+        val unavailable = candidate(IntentKind.BROWSER, "com.example", "OldBrowser").copy(unavailable = true)
+        val restricted = candidate(IntentKind.BROWSER, "com.example", "PrivateBrowser").copy(restricted = true)
+        val derived = deriveFullySelectedPackages(listOf(visible, unavailable, restricted), setOf(visible.rule))
+        assertEquals(setOf("com.example"), derived[VisibilityScope.BROWSER])
+    }
+}


### PR DESCRIPTION
全面扩展“打开方式”分类规则、排序和兼容诊断，并补齐 ES 文件管理器等非标准调用路径。

主要行为：
- 规则页与排序页支持“打开方式 → 全部 + 内置类型”，包括 PDF、Word、Excel、PowerPoint、EPUB、APK、Torrent、Markdown、CSV、JSON、XML、SVG、GIF、图片、视频、音频、文本、压缩包、magnet、geo、mailto、tel、sms 等。
- “全部”继续编辑通用 OPEN 配置；分类型规则实际生效为“通用 OPEN + 当前类型专用规则”的并集。
- 分类型页面明确显示“继承自全部 / 当前类型专用”来源；继承项不能在分类型中误取消。
- 分类型排序为空时继承“全部”排序；首次修改会创建专用排序，并可一键“恢复继承全部”。
- 新增 8 个可配置自定义打开类型槽位，可自定义名称、MIME 和文件后缀，并拥有独立规则、独立排序、继承和候选扫描。
- 应用隐藏兼容改为显式“命中分类”多选，支持 全部 / 分享 / 多文件分享 / 打开方式 / 浏览器 / 文本处理；默认不选择任何分类，因此升级后不会自动启用包级隐藏。
- 包级隐藏目标只来自所选分类中“应用整行完整勾选”的包；只勾部分组件形成半勾选时不会加入。多选分类时取完整勾选包的并集；“全部”代表所有顶层分类的并集。
- 来源应用列表与命中分类分开配置：前者决定哪些调用方需要兼容隐藏，后者决定哪些规则分类可贡献目标包。
- 完整勾选包由当前 Intent 候选目录和规则状态自动派生，规则/扫描变化会自动重算；派生结果不写进备份，避免保存过期半选状态。
- 修复 selector Intent 的分类路径；未知/opaque MIME 可按受控文件后缀回退，具体未知 MIME 不会被后缀错误覆盖。
- “用实际文件检查”升级为最终效果预览：显示识别类型、原始候选、预计最终候选、规则来源、排序位置和空列表保护。
- 状态页增加 system_server 实际 Hook 命中计数（Intent 查询、应用可见性、排序）；Resolver 进程排序仍通过诊断日志核验。
- 诊断日志不再记录完整文件名/URI，只记录安全扩展名和识别类型；诊断包同时导出 typed OPEN / 自定义类型配置和运行命中数据。
- Root 组件页增加“只看本应用修改”历史筛选；仅在 Root 命令成功且系统状态核验成功后记录历史，系统当前状态仍始终实时读取。
- Root 组件操作从 MainViewModel 拆到 RootComponentsController；OPEN 继承投影拆到 OpenUiPolicy，降低主 ViewModel 职责。
- legacy DefaultOpenConfig / TileConfig 不再写入新远程配置或新备份；源码仅保留 transient 兼容占位，旧 JSON 字段通过 ignoreUnknownKeys 安全忽略。
- 备份格式升级到 v9，并保持旧版本导入兼容。
- PR Debug 构建会上传 APK artifact，方便直接测试。

验证：
- Debug assemble 成功。
- Debug APK artifact 上传成功。
- testDebugUnitTest 全部通过，包含“半勾选不加入”“多分类并集”“默认关闭”回归测试。
- PR Release 无签名编译校验通过。

最终验证 head：e4ddd0713982d9dfdd81b4e3a89d7d7e03b3df41。