### PR TITLE
Fix audit findings in runtime and configuration

### DIFF
--- a/app/src/main/java/com/yagay/ListCleaner/data/RuleRepository.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/RuleRepository.kt
@@ -11,6 +11,7 @@ import com.yagay.ListCleaner.domain.ModuleConfig
 import com.yagay.ListCleaner.domain.OpenPreset
 import com.yagay.ListCleaner.domain.OpenTypeConfig
 import com.yagay.ListCleaner.domain.CustomOpenDefinition
+import com.yagay.ListCleaner.domain.PackageIdentity
 import com.yagay.ListCleaner.domain.VisibilityCompatConfig
 import com.yagay.ListCleaner.domain.VisibilityScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -61,12 +62,7 @@ class RuleRepository(context: Context) {
     }
 
     @Synchronized fun restoreRemote(config: ModuleConfig) {
-        config.validated()
-        replace(config.rules, config.mode != DisplayMode.SHOW_SELECTED, config.priorities, config.mode, config.openTypes)
-        setHiddenFromApps(config.hiddenFromApps)
-        setVisibilityScopes(config.visibilityCompat.scopes)
-        setDiagnosticMode(config.diagnostic)
-        markInitialized()
+        applyConfig(config, config.mode != DisplayMode.SHOW_SELECTED)
     }
 
     /** Legacy ModuleConfig fields remain deserializable, but new remote snapshots always use defaults. */
@@ -81,11 +77,7 @@ class RuleRepository(context: Context) {
     )
 
     @Synchronized fun setHiddenFromApps(packages: Set<String>) {
-        val self = "com.yagay.ListCleaner"
-        val valid = packages.asSequence().map(String::trim)
-            .filter { it.isNotEmpty() && it != "android" && it != self && it.length <= 255 && it.none { ch -> ch.isWhitespace() || ch.isISOControl() || ch == '|' } }
-            .take(2_001).toSet()
-        require(valid.size <= 2_000) { appContext.getString(R.string.repo_hidden_apps_too_many) }
+        val valid = normalizeHiddenApps(packages)
         if (valid == mutableHiddenFromApps.value) return
         mutableHiddenFromApps.value = valid
         prefs.edit().putStringSet(KEY_HIDDEN_FROM_APPS, valid).apply()
@@ -248,25 +240,18 @@ class RuleRepository(context: Context) {
         rules: Set<ComponentRule>, blacklist: Boolean, priorities: PriorityConfig = PriorityConfig(),
         displayMode: DisplayMode = DisplayMode.fromStored(null, blacklist), openTypes: OpenTypeConfig = OpenTypeConfig()
     ) {
-        require(rules.size <= MAX_RULES) { appContext.getString(R.string.repo_backup_too_many_rules) }
-        require(rules.all(ComponentRule::isValid)) { appContext.getString(R.string.repo_backup_invalid_component) }
-        priorities.validated()
-        openTypes.validated()
-        mutableRules.value = rules.mapNotNull { ComponentRule.fromId(it.id) }.toSet()
-        mutableMode.value = displayMode
-        mutablePriorities.value = priorities
-        mutableOpenTypes.value = openTypes.validated()
-        mutableVisibilityFullPackages.value = emptyMap()
-        prefs.edit()
-            .putStringSet(KEY_RULES, mutableRules.value.map(ComponentRule::id).toSet())
-            .putBoolean(KEY_BLACKLIST, blacklist)
-            .putString(KEY_DISPLAY_MODE, displayMode.name)
-            .putString(KEY_PRIORITIES, encodePriorities(priorities))
-            .putString(KEY_OPEN_TYPES, json.encodeToString(OpenTypeConfig.serializer(), mutableOpenTypes.value))
-            .remove(KEY_TILES)
-            .remove(KEY_DEFAULT_OPEN)
-            .apply()
-        mutableRevision.value++
+        applyConfig(
+            ModuleConfig(
+                rules = rules,
+                mode = displayMode,
+                priorities = priorities,
+                diagnostic = mutableDiagnostic.value,
+                hiddenFromApps = mutableHiddenFromApps.value,
+                openTypes = openTypes,
+                visibilityCompat = VisibilityCompatConfig(scopes = mutableVisibilityScopes.value)
+            ),
+            blacklist
+        )
     }
 
     @Synchronized fun exportJson(): String = json.encodeToString(
@@ -283,25 +268,87 @@ class RuleRepository(context: Context) {
         )
     )
 
-    fun importJson(content: String) {
+    @Synchronized fun importJson(content: String) {
         require(content.length <= MAX_BACKUP_CHARS) { appContext.getString(R.string.repo_backup_too_large) }
         val backup = json.decodeFromString(RuleBackup.serializer(), content)
         require(backup.version in 1..9) {
             appContext.getString(R.string.repo_backup_unsupported_version, backup.version)
         }
-        // Legacy tiles/defaultOpen are deliberately ignored: those features no longer have runtime consumers.
-        replace(
-            backup.rules,
-            backup.blacklist,
-            if (backup.version == 1) PriorityConfig() else backup.priorities,
-            if (backup.version >= 3) requireNotNull(backup.displayMode) {
-                appContext.getString(R.string.repo_backup_missing_display_mode)
-            } else DisplayMode.fromStored(null, backup.blacklist),
-            if (backup.version >= 7) backup.openTypes else OpenTypeConfig()
+        val displayMode = if (backup.version >= 3) requireNotNull(backup.displayMode) {
+            appContext.getString(R.string.repo_backup_missing_display_mode)
+        } else DisplayMode.fromStored(null, backup.blacklist)
+        applyConfig(
+            ModuleConfig(
+                rules = backup.rules,
+                mode = displayMode,
+                priorities = if (backup.version == 1) PriorityConfig() else backup.priorities,
+                diagnostic = mutableDiagnostic.value,
+                hiddenFromApps = if (backup.version >= 5) backup.hiddenFromApps else emptySet(),
+                openTypes = if (backup.version >= 7) backup.openTypes else OpenTypeConfig(),
+                visibilityCompat = VisibilityCompatConfig(
+                    scopes = if (backup.version >= 9) backup.visibilityScopes else emptySet()
+                )
+            ),
+            backup.blacklist
         )
-        setHiddenFromApps(if (backup.version >= 5) backup.hiddenFromApps else emptySet())
-        setVisibilityScopes(if (backup.version >= 9) backup.visibilityScopes else emptySet())
-        markInitialized()
+    }
+
+    /**
+     * Applies a complete persisted configuration as one SharedPreferences transaction and exposes
+     * exactly one revision. Derived full-package visibility targets are intentionally discarded and
+     * rebuilt from the current catalog after restore/import.
+     */
+    private fun applyConfig(config: ModuleConfig, legacyBlacklist: Boolean) {
+        require(config.rules.size <= MAX_RULES) { appContext.getString(R.string.repo_backup_too_many_rules) }
+        require(config.rules.all(ComponentRule::isValid)) { appContext.getString(R.string.repo_backup_invalid_component) }
+
+        val canonicalRules = config.rules.mapNotNull { ComponentRule.fromId(it.id) }.toSet()
+        val priorities = config.priorities.validated()
+        val openTypes = config.openTypes.validated()
+        val hiddenFromApps = normalizeHiddenApps(config.hiddenFromApps)
+        val visibilityScopes = config.visibilityCompat.scopes.toSet()
+        val prepared = config.copy(
+            rules = canonicalRules,
+            priorities = priorities,
+            hiddenFromApps = hiddenFromApps,
+            openTypes = openTypes,
+            visibilityCompat = VisibilityCompatConfig(scopes = visibilityScopes)
+        ).validated()
+
+        prefs.edit()
+            .putStringSet(KEY_RULES, prepared.rules.map(ComponentRule::id).toSet())
+            .putBoolean(KEY_BLACKLIST, legacyBlacklist)
+            .putString(KEY_DISPLAY_MODE, prepared.mode.name)
+            .putString(KEY_PRIORITIES, encodePriorities(prepared.priorities))
+            .putString(KEY_OPEN_TYPES, json.encodeToString(OpenTypeConfig.serializer(), prepared.openTypes))
+            .putBoolean(KEY_DIAGNOSTIC, prepared.diagnostic)
+            .putStringSet(KEY_HIDDEN_FROM_APPS, prepared.hiddenFromApps)
+            .putStringSet(KEY_VISIBILITY_SCOPES, visibilityScopes.map { it.name }.toSet())
+            .putBoolean(KEY_INITIALIZED, true)
+            .remove(KEY_TILES)
+            .remove(KEY_DEFAULT_OPEN)
+            .apply()
+
+        mutableRules.value = prepared.rules
+        mutableMode.value = prepared.mode
+        mutablePriorities.value = prepared.priorities
+        mutableOpenTypes.value = prepared.openTypes
+        mutableDiagnostic.value = prepared.diagnostic
+        mutableHiddenFromApps.value = prepared.hiddenFromApps
+        mutableVisibilityScopes.value = visibilityScopes
+        mutableVisibilityFullPackages.value = emptyMap()
+        mutableRevision.value++
+    }
+
+    private fun normalizeHiddenApps(packages: Set<String>): Set<String> {
+        val self = "com.yagay.ListCleaner"
+        val valid = packages.asSequence()
+            .map(String::trim)
+            .filter { it != "android" && it != self && PackageIdentity.valid(it) }
+            .take(2_001)
+            .toSet()
+        require(valid.size <= 2_000) { appContext.getString(R.string.repo_hidden_apps_too_many) }
+        return valid
     }
 
     private fun updateRules(next: Set<ComponentRule>) {

--- a/app/src/main/java/com/yagay/ListCleaner/domain/ModuleConfig.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/ModuleConfig.kt
@@ -27,12 +27,9 @@ data class ModuleConfig(
         require(rules.size <= 20_000 && rules.all(ComponentRule::isValid))
         priorities.validated()
         require(managerAppId == -1 || ManagerIdentity.valid(managerAppId))
-        require(hiddenFromApps.size <= 2_000 && hiddenFromApps.all(::validPackageName))
+        require(hiddenFromApps.size <= 2_000 && hiddenFromApps.all(PackageIdentity::valid))
         openTypes.validated()
         visibilityCompat.validated()
         return this
     }
-
-    private fun validPackageName(value: String): Boolean =
-        value.isNotBlank() && value.length <= 255 && value.none { it.isWhitespace() || it.isISOControl() || it == '|' }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/domain/PackageIdentity.java
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/PackageIdentity.java
@@ -5,12 +5,12 @@ import java.util.regex.Pattern;
 /** Shared validation for package identities persisted by manager/runtime configuration. */
 public final class PackageIdentity {
     private static final Pattern PACKAGE = Pattern.compile(
-        "[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)+"
+        "[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*"
     );
 
     private PackageIdentity() {}
 
     public static boolean valid(String value) {
-        return value != null && value.length() <= 255 && PACKAGE.matcher(value).matches();
+        return value != null && !value.isEmpty() && value.length() <= 255 && PACKAGE.matcher(value).matches();
     }
 }

--- a/app/src/main/java/com/yagay/ListCleaner/domain/PackageIdentity.java
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/PackageIdentity.java
@@ -1,0 +1,16 @@
+package com.yagay.ListCleaner.domain;
+
+import java.util.regex.Pattern;
+
+/** Shared validation for package identities persisted by manager/runtime configuration. */
+public final class PackageIdentity {
+    private static final Pattern PACKAGE = Pattern.compile(
+        "[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)+"
+    );
+
+    private PackageIdentity() {}
+
+    public static boolean valid(String value) {
+        return value != null && value.length() <= 255 && PACKAGE.matcher(value).matches();
+    }
+}

--- a/app/src/main/java/com/yagay/ListCleaner/domain/VisibilityCompat.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/VisibilityCompat.kt
@@ -31,7 +31,7 @@ data class VisibilityCompatConfig(
         fullPackages.forEach { (scope, packages) ->
             require(scope != VisibilityScope.ALL) { "ALL is derived from concrete categories" }
             require(packages.size <= 20_000)
-            require(packages.all(::validPackageName))
+            require(packages.all(PackageIdentity::valid))
         }
         return this
     }
@@ -43,9 +43,6 @@ data class VisibilityCompatConfig(
         } else scopes.filter { it != VisibilityScope.ALL }
         return concrete.asSequence().flatMap { fullPackages[it].orEmpty().asSequence() }.toSet()
     }
-
-    private fun validPackageName(value: String): Boolean =
-        value.isNotBlank() && value.length <= 255 && value.none { it.isWhitespace() || it.isISOControl() || it == '|' }
 }
 
 /**

--- a/app/src/main/java/com/yagay/ListCleaner/runtime/ServiceSession.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/runtime/ServiceSession.kt
@@ -15,26 +15,50 @@ data class ServiceSession(
     val service: XposedService
 )
 
-/** Thread-safe owner for the currently active XposedService session. */
-class ServiceSessionRegistry {
+/** Small generic generation registry so reconnect ordering can be unit-tested without libxposed mocks. */
+internal class GenerationRegistry<T : Any> {
+    data class Token<T : Any>(val generation: Long, val value: T)
+
     private val counter = AtomicLong(0L)
 
     @Volatile
-    private var current: ServiceSession? = null
+    private var current: Token<T>? = null
 
-    fun bind(service: XposedService): ServiceSession = synchronized(this) {
-        ServiceSession(counter.incrementAndGet(), service).also { current = it }
+    fun bind(value: T): Token<T> = synchronized(this) {
+        Token(counter.incrementAndGet(), value).also { current = it }
     }
 
-    fun clear(service: XposedService): ServiceSession? = synchronized(this) {
-        current?.takeIf { it.service === service }?.also { current = null }
+    fun clear(value: T): Token<T>? = synchronized(this) {
+        current?.takeIf { it.value === value }?.also { current = null }
     }
 
-    fun snapshot(): ServiceSession? = current
+    fun snapshot(): Token<T>? = current
 
-    fun isCurrent(session: ServiceSession?): Boolean {
-        if (session == null) return current == null
+    fun isCurrent(token: Token<T>?): Boolean {
+        if (token == null) return current == null
         val active = current ?: return false
-        return active.generation == session.generation && active.service === session.service
+        return active.generation == token.generation && active.value === token.value
     }
+}
+
+/** Thread-safe owner for the currently active XposedService session. */
+class ServiceSessionRegistry {
+    private val registry = GenerationRegistry<XposedService>()
+
+    fun bind(service: XposedService): ServiceSession {
+        val token = registry.bind(service)
+        return ServiceSession(token.generation, token.value)
+    }
+
+    fun clear(service: XposedService): ServiceSession? = registry.clear(service)?.let {
+        ServiceSession(it.generation, it.value)
+    }
+
+    fun snapshot(): ServiceSession? = registry.snapshot()?.let {
+        ServiceSession(it.generation, it.value)
+    }
+
+    fun isCurrent(session: ServiceSession?): Boolean = registry.isCurrent(
+        session?.let { GenerationRegistry.Token(it.generation, it.service) }
+    )
 }

--- a/app/src/main/java/com/yagay/ListCleaner/ui/ModuleRuntimeController.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/ModuleRuntimeController.kt
@@ -54,7 +54,12 @@ class ModuleRuntimeController(
 ) {
     private val scopeDetector = ResolverScopeDetector(app)
     private var statusGeneration = 0L
+    private var updateGeneration = 0L
+    private var scopeGeneration = 0L
     private var scopeRequestInFlight = false
+
+    @Volatile
+    private var cachedDetection: ScopeDetection? = null
 
     private val mutableStatus = MutableStateFlow(ModuleStatus())
     val status: StateFlow<ModuleStatus> = mutableStatus
@@ -65,10 +70,15 @@ class ModuleRuntimeController(
     private val mutableUpdateMessage = MutableStateFlow<String?>(null)
     val updateMessage: StateFlow<String?> = mutableUpdateMessage
 
-    suspend fun readStatus(session: ServiceSession? = app.currentSession()): ModuleStatus {
+    suspend fun readStatus(
+        session: ServiceSession? = app.currentSession(),
+        refreshDetection: Boolean = false
+    ): ModuleStatus {
         val generation = ++statusGeneration
         val status = withContext(Dispatchers.IO) {
-            val detection = scopeDetector.detect()
+            val detection = if (refreshDetection || cachedDetection == null) {
+                scopeDetector.detect().also { cachedDetection = it }
+            } else requireNotNull(cachedDetection)
             var result = ModuleStatus(connected = session != null, detection = detection)
             val service = session?.service
             if (service != null) {
@@ -100,28 +110,30 @@ class ModuleRuntimeController(
 
     fun refresh(sync: Boolean = true) {
         scope.launch {
-            readStatus()
+            readStatus(refreshDetection = true)
             if (sync) app.synchronize()
         }
     }
 
     fun applyUpdate(onFinished: () -> Unit) {
         if (mutableUpdating.value) return
+        val generation = ++updateGeneration
         mutableUpdating.value = true
         mutableUpdateMessage.value = app.getString(R.string.update_detecting_targets)
         scope.launch {
             val session = app.currentSession()
+            fun current(): Boolean = generation == updateGeneration && app.isCurrent(session)
             try {
                 val active = session ?: error(app.getString(R.string.update_lsposed_disconnected))
                 val bound = active.service
                 val targets = withContext(Dispatchers.IO) { bound.runningTargets }
-                if (!app.isCurrent(active)) return@launch
+                if (!current()) return@launch
                 val pending = targets.filter {
                     !RuntimeProtocol.current(it.state.name, it.loadedVersionCode, BuildConfig.VERSION_CODE.toLong())
                 }
                 val messages = mutableListOf<String>()
                 for (target in pending) {
-                    if (!app.isCurrent(active)) return@launch
+                    if (!current()) return@launch
                     try {
                         if (target.state == HookedTarget.State.RELOADING) {
                             messages += app.getString(R.string.update_target_reloading, target.processName)
@@ -138,7 +150,7 @@ class ModuleRuntimeController(
                         val result = withTimeoutOrNull(15_000) {
                             requestHotReload(bound, target)
                         }
-                        if (!app.isCurrent(active)) return@launch
+                        if (!current()) return@launch
                         val resultText = when (result?.status()) {
                             HotReloadResult.Status.SUCCEEDED -> app.getString(R.string.update_succeeded)
                             HotReloadResult.Status.UNSUPPORTED -> app.getString(R.string.update_unsupported)
@@ -155,7 +167,7 @@ class ModuleRuntimeController(
                         throw cancelled
                     } catch (failure: Exception) {
                         Log.e(TAG, "Hot reload request failed for ${target.processName}", failure)
-                        if (!app.isCurrent(active)) return@launch
+                        if (!current()) return@launch
                         messages += app.getString(
                             R.string.update_request_failed,
                             target.processName,
@@ -163,7 +175,7 @@ class ModuleRuntimeController(
                         )
                     }
                 }
-                if (!app.isCurrent(active)) return@launch
+                if (!current()) return@launch
                 mutableUpdateMessage.value = if (messages.isEmpty()) {
                     app.getString(R.string.update_nothing_pending)
                 } else messages.joinToString("\n")
@@ -172,36 +184,40 @@ class ModuleRuntimeController(
                 throw cancelled
             } catch (failure: Exception) {
                 Log.e(TAG, "Hot update check failed", failure)
-                if (session == null || app.isCurrent(session)) {
+                if (current()) {
                     mutableUpdateMessage.value = app.getString(
                         R.string.update_check_failed,
                         app.getString(R.string.update_old_module_rejected)
                     )
                 }
             } finally {
-                if (session != null && !app.isCurrent(session)) mutableUpdateMessage.value = null
-                mutableUpdating.value = false
+                if (generation == updateGeneration) {
+                    if (!app.isCurrent(session)) mutableUpdateMessage.value = null
+                    mutableUpdating.value = false
+                }
             }
         }
     }
 
     fun requestScope() {
         if (scopeRequestInFlight) return
+        val generation = ++scopeGeneration
         scopeRequestInFlight = true
         mutableStatus.value = mutableStatus.value.copy(requesting = true, message = null)
         scope.launch {
             val session = app.currentSession()
+            fun current(): Boolean = generation == scopeGeneration && app.isCurrent(session)
             try {
                 val active = session ?: error(app.getString(R.string.scope_lsposed_not_connected))
                 val service = active.service
-                val current = readStatus(active)
-                check(app.isCurrent(active)) { app.getString(R.string.scope_service_changed_retry) }
-                check(current.scopeKnown) { current.error ?: app.getString(R.string.scope_granted_read_failed) }
-                check(current.detection.recommended.isNotEmpty()) { app.getString(R.string.scope_no_auto_host) }
-                val missing = current.missingScope.toList()
+                val currentStatus = readStatus(active)
+                check(current()) { app.getString(R.string.scope_service_changed_retry) }
+                check(currentStatus.scopeKnown) { currentStatus.error ?: app.getString(R.string.scope_granted_read_failed) }
+                check(currentStatus.detection.recommended.isNotEmpty()) { app.getString(R.string.scope_no_auto_host) }
+                val missing = currentStatus.missingScope.toList()
                 if (missing.isEmpty()) {
-                    if (app.isCurrent(active)) {
-                        mutableStatus.value = current.copy(
+                    if (current()) {
+                        mutableStatus.value = currentStatus.copy(
                             requesting = true,
                             message = app.getString(R.string.scope_all_recommended_granted)
                         )
@@ -221,7 +237,7 @@ class ModuleRuntimeController(
                         })
                     }
                 }
-                check(app.isCurrent(active)) { app.getString(R.string.scope_service_changed_result) }
+                check(current()) { app.getString(R.string.scope_service_changed_result) }
                 val refreshed = readStatus(active)
                 val message = when {
                     approved == null -> app.getString(R.string.scope_request_timeout)
@@ -232,20 +248,22 @@ class ModuleRuntimeController(
                     )
                     else -> app.getString(R.string.scope_granted_confirmed)
                 }
-                if (app.isCurrent(active)) mutableStatus.value = refreshed.copy(message = message, requesting = true)
+                if (current()) mutableStatus.value = refreshed.copy(message = message, requesting = true)
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (failure: Exception) {
                 Log.e(TAG, "Scope request failed", failure)
-                if (session == null || app.isCurrent(session)) {
+                if (current()) {
                     mutableStatus.value = mutableStatus.value.copy(error = app.getString(R.string.scope_request_failed))
                 }
             } finally {
-                scopeRequestInFlight = false
-                if (session != null && app.isCurrent(session)) {
-                    mutableStatus.value = mutableStatus.value.copy(requesting = false)
-                } else {
-                    readStatus()
+                if (generation == scopeGeneration) {
+                    scopeRequestInFlight = false
+                    if (app.isCurrent(session)) {
+                        mutableStatus.value = mutableStatus.value.copy(requesting = false)
+                    } else {
+                        readStatus()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/yagay/ListCleaner/ui/ModuleRuntimeController.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/ModuleRuntimeController.kt
@@ -40,7 +40,7 @@ data class ModuleStatus(
     val extraScope: Set<String> get() = grantedScope - detection.hosts.map { it.packageName }.toSet()
     val resolverLoaded: Boolean get() = runningTargets.any { target ->
         RuntimeProtocol.current(target.state, target.version, BuildConfig.VERSION_CODE.toLong()) &&
-            detection.hosts.any { it.processName == target.processName }
+            detection.hosts.any { host -> host.packageName != "system" && host.processName == target.processName }
     }
     val outdated: Boolean get() = runningTargets.any {
         !RuntimeProtocol.current(it.state, it.version, BuildConfig.VERSION_CODE.toLong())

--- a/app/src/main/java/com/yagay/ListCleaner/ui/RuntimeCapabilities.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/RuntimeCapabilities.kt
@@ -1,6 +1,8 @@
 package com.yagay.ListCleaner.ui
 
+import com.yagay.ListCleaner.BuildConfig
 import com.yagay.ListCleaner.RuntimeStatus
+import com.yagay.ListCleaner.domain.RuntimeProtocol
 
 enum class RuntimeCapability {
     FILTERING,
@@ -26,22 +28,60 @@ data class CapabilityStatus(
 /**
  * Conservative capability projection for UI/diagnostics.
  *
- * A zero hit count is deliberately reported as LOADED_UNOBSERVED rather than unsupported: the
- * feature may simply not have been exercised since the hooked process started.
+ * Requirements are evaluated per capability. Resolver ordering must not be marked broken merely
+ * because an unrelated target is stale, and system-server filtering/visibility must not inherit a
+ * missing Resolver scope. A zero hit count remains LOADED_UNOBSERVED rather than unsupported.
  */
 fun runtimeCapabilities(module: ModuleStatus, runtime: RuntimeStatus): List<CapabilityStatus> {
-    fun stateFor(hits: Long): CapabilityState = when {
-        !module.connected -> CapabilityState.DISCONNECTED
-        module.outdated -> CapabilityState.OUTDATED
-        module.missingScope.isNotEmpty() -> CapabilityState.MISSING_SCOPE
-        !runtime.ready -> CapabilityState.NOT_READY
-        hits > 0 -> CapabilityState.OBSERVED
-        else -> CapabilityState.LOADED_UNOBSERVED
+    val resolverHosts = module.detection.hosts.filter { it.packageName != "system" }
+
+    fun stateFor(capability: RuntimeCapability, hits: Long): CapabilityState {
+        if (!module.connected) return CapabilityState.DISCONNECTED
+        if (!module.scopeKnown) return CapabilityState.NOT_READY
+
+        val requiredPackages: Set<String>
+        val requiredProcesses: Set<String>
+        when (capability) {
+            RuntimeCapability.FILTERING,
+            RuntimeCapability.PACKAGE_VISIBILITY -> {
+                requiredPackages = setOf("system")
+                requiredProcesses = setOf("system")
+            }
+            RuntimeCapability.ORDERING -> {
+                if (resolverHosts.isEmpty()) return CapabilityState.NOT_READY
+                requiredPackages = resolverHosts.map { it.packageName }.toSet()
+                requiredProcesses = resolverHosts.map { it.processName }.toSet()
+            }
+        }
+
+        if ((requiredPackages - module.grantedScope).isNotEmpty()) return CapabilityState.MISSING_SCOPE
+
+        val relevantTargets = module.runningTargets.filter { it.processName in requiredProcesses }
+        if (relevantTargets.any {
+                !RuntimeProtocol.current(it.state, it.version, BuildConfig.VERSION_CODE.toLong())
+            }) {
+            return CapabilityState.OUTDATED
+        }
+        if (relevantTargets.isEmpty()) return CapabilityState.NOT_READY
+        if (!runtime.ready) return CapabilityState.NOT_READY
+        return if (hits > 0) CapabilityState.OBSERVED else CapabilityState.LOADED_UNOBSERVED
     }
 
     return listOf(
-        CapabilityStatus(RuntimeCapability.FILTERING, stateFor(runtime.queryHits), runtime.queryHits),
-        CapabilityStatus(RuntimeCapability.ORDERING, stateFor(runtime.orderingHits), runtime.orderingHits),
-        CapabilityStatus(RuntimeCapability.PACKAGE_VISIBILITY, stateFor(runtime.visibilityHits), runtime.visibilityHits)
+        CapabilityStatus(
+            RuntimeCapability.FILTERING,
+            stateFor(RuntimeCapability.FILTERING, runtime.queryHits),
+            runtime.queryHits
+        ),
+        CapabilityStatus(
+            RuntimeCapability.ORDERING,
+            stateFor(RuntimeCapability.ORDERING, runtime.orderingHits),
+            runtime.orderingHits
+        ),
+        CapabilityStatus(
+            RuntimeCapability.PACKAGE_VISIBILITY,
+            stateFor(RuntimeCapability.PACKAGE_VISIBILITY, runtime.visibilityHits),
+            runtime.visibilityHits
+        )
     )
 }

--- a/app/src/test/java/com/yagay/ListCleaner/domain/PackageIdentityTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/PackageIdentityTest.kt
@@ -1,0 +1,31 @@
+package com.yagay.ListCleaner.domain
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PackageIdentityTest {
+    @Test
+    fun acceptsOrdinaryAndroidPackages() {
+        assertTrue(PackageIdentity.valid("com.example.app"))
+        assertTrue(PackageIdentity.valid("com.example_2.feature3"))
+        assertTrue(PackageIdentity.valid("_vendor.product"))
+    }
+
+    @Test
+    fun rejectsShellAndMalformedValues() {
+        assertFalse(PackageIdentity.valid(""))
+        assertFalse(PackageIdentity.valid("android"))
+        assertFalse(PackageIdentity.valid("com.example.bad-name"))
+        assertFalse(PackageIdentity.valid("com.example.app;id"))
+        assertFalse(PackageIdentity.valid("com.example.app name"))
+        assertFalse(PackageIdentity.valid("1com.example.app"))
+        assertFalse(PackageIdentity.valid("com..example"))
+    }
+
+    @Test
+    fun rejectsOversizedPackages() {
+        val value = "com." + "a".repeat(252)
+        assertFalse(PackageIdentity.valid(value))
+    }
+}

--- a/app/src/test/java/com/yagay/ListCleaner/domain/PackageIdentityTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/domain/PackageIdentityTest.kt
@@ -10,12 +10,12 @@ class PackageIdentityTest {
         assertTrue(PackageIdentity.valid("com.example.app"))
         assertTrue(PackageIdentity.valid("com.example_2.feature3"))
         assertTrue(PackageIdentity.valid("_vendor.product"))
+        assertTrue(PackageIdentity.valid("android"))
     }
 
     @Test
     fun rejectsShellAndMalformedValues() {
         assertFalse(PackageIdentity.valid(""))
-        assertFalse(PackageIdentity.valid("android"))
         assertFalse(PackageIdentity.valid("com.example.bad-name"))
         assertFalse(PackageIdentity.valid("com.example.app;id"))
         assertFalse(PackageIdentity.valid("com.example.app name"))

--- a/app/src/test/java/com/yagay/ListCleaner/runtime/ServiceSessionRegistryTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/runtime/ServiceSessionRegistryTest.kt
@@ -1,0 +1,59 @@
+package com.yagay.ListCleaner.runtime
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ServiceSessionRegistryTest {
+    @Test
+    fun rebindingSameObjectCreatesNewGeneration() {
+        val registry = GenerationRegistry<Any>()
+        val service = Any()
+
+        val first = registry.bind(service)
+        val second = registry.bind(service)
+
+        assertNotEquals(first.generation, second.generation)
+        assertFalse(registry.isCurrent(first))
+        assertTrue(registry.isCurrent(second))
+    }
+
+    @Test
+    fun staleClearCannotRemoveNewBinding() {
+        val registry = GenerationRegistry<Any>()
+        val firstService = Any()
+        val secondService = Any()
+
+        registry.bind(firstService)
+        val second = registry.bind(secondService)
+
+        assertNull(registry.clear(firstService))
+        assertTrue(registry.isCurrent(second))
+        assertSame(secondService, registry.snapshot()?.value)
+    }
+
+    @Test
+    fun clearedTokenNeverBecomesCurrentAgain() {
+        val registry = GenerationRegistry<Any>()
+        val service = Any()
+
+        val first = registry.bind(service)
+        registry.clear(service)
+        val second = registry.bind(service)
+
+        assertFalse(registry.isCurrent(first))
+        assertTrue(registry.isCurrent(second))
+    }
+
+    @Test
+    fun nullRepresentsOnlyNoActiveBinding() {
+        val registry = GenerationRegistry<Any>()
+
+        assertTrue(registry.isCurrent(null))
+        registry.bind(Any())
+        assertFalse(registry.isCurrent(null))
+    }
+}

--- a/app/src/test/java/com/yagay/ListCleaner/ui/RuntimeCapabilitiesTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/ui/RuntimeCapabilitiesTest.kt
@@ -5,6 +5,7 @@ import com.yagay.ListCleaner.RuntimeStatus
 import com.yagay.ListCleaner.data.ResolverHost
 import com.yagay.ListCleaner.data.ScopeDetection
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class RuntimeCapabilitiesTest {
@@ -103,5 +104,14 @@ class RuntimeCapabilitiesTest {
         assertEquals(CapabilityState.LOADED_UNOBSERVED, states[RuntimeCapability.FILTERING])
         assertEquals(CapabilityState.NOT_READY, states[RuntimeCapability.ORDERING])
         assertEquals(CapabilityState.LOADED_UNOBSERVED, states[RuntimeCapability.PACKAGE_VISIBILITY])
+    }
+
+    @Test
+    fun systemTargetAloneDoesNotCountAsResolverLoaded() {
+        val module = healthyModule().copy(
+            runningTargets = listOf(currentTarget("system"))
+        )
+
+        assertFalse(module.resolverLoaded)
     }
 }

--- a/app/src/test/java/com/yagay/ListCleaner/ui/RuntimeCapabilitiesTest.kt
+++ b/app/src/test/java/com/yagay/ListCleaner/ui/RuntimeCapabilitiesTest.kt
@@ -1,5 +1,6 @@
 package com.yagay.ListCleaner.ui
 
+import com.yagay.ListCleaner.BuildConfig
 import com.yagay.ListCleaner.RuntimeStatus
 import com.yagay.ListCleaner.data.ResolverHost
 import com.yagay.ListCleaner.data.ScopeDetection
@@ -7,12 +8,32 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class RuntimeCapabilitiesTest {
+    private val systemHost = ResolverHost("system", "PackageManagerService", "system", setOf("global"))
+    private val resolverHost = ResolverHost(
+        "com.android.intentresolver",
+        "com.android.intentresolver.ResolverActivity",
+        "com.android.intentresolver",
+        setOf("share")
+    )
+
+    private fun currentTarget(process: String) = RunningTargetStatus(
+        process,
+        "UP_TO_DATE",
+        BuildConfig.VERSION_CODE.toLong()
+    )
+
+    private fun healthyModule(): ModuleStatus = ModuleStatus(
+        connected = true,
+        scopeKnown = true,
+        grantedScope = setOf("system", "com.android.intentresolver"),
+        runningTargets = listOf(currentTarget("system"), currentTarget("com.android.intentresolver")),
+        detection = ScopeDetection(hosts = listOf(systemHost, resolverHost))
+    )
+
     @Test
     fun zeroHitsAreUnobservedNotUnsupported() {
-        val module = ModuleStatus(connected = true, scopeKnown = true)
-        val runtime = RuntimeStatus(ready = true)
-
-        val states = runtimeCapabilities(module, runtime).associate { it.capability to it.state }
+        val states = runtimeCapabilities(healthyModule(), RuntimeStatus(ready = true))
+            .associate { it.capability to it.state }
 
         assertEquals(CapabilityState.LOADED_UNOBSERVED, states[RuntimeCapability.FILTERING])
         assertEquals(CapabilityState.LOADED_UNOBSERVED, states[RuntimeCapability.ORDERING])
@@ -21,10 +42,8 @@ class RuntimeCapabilitiesTest {
 
     @Test
     fun hitsPromoteOnlyObservedCapability() {
-        val module = ModuleStatus(connected = true, scopeKnown = true)
         val runtime = RuntimeStatus(ready = true, queryHits = 4, orderingHits = 0, visibilityHits = 2)
-
-        val states = runtimeCapabilities(module, runtime).associate { it.capability to it.state }
+        val states = runtimeCapabilities(healthyModule(), runtime).associate { it.capability to it.state }
 
         assertEquals(CapabilityState.OBSERVED, states[RuntimeCapability.FILTERING])
         assertEquals(CapabilityState.LOADED_UNOBSERVED, states[RuntimeCapability.ORDERING])
@@ -32,19 +51,57 @@ class RuntimeCapabilitiesTest {
     }
 
     @Test
-    fun missingScopeTakesPrecedenceOverHitCounts() {
-        val module = ModuleStatus(
-            connected = true,
-            scopeKnown = true,
-            grantedScope = emptySet(),
-            detection = ScopeDetection(
-                hosts = listOf(ResolverHost("system", "PackageManagerService", "system", setOf("global")))
-            )
-        )
+    fun missingResolverScopeOnlyAffectsOrdering() {
+        val module = healthyModule().copy(grantedScope = setOf("system"))
         val runtime = RuntimeStatus(ready = true, queryHits = 9, orderingHits = 9, visibilityHits = 9)
+        val states = runtimeCapabilities(module, runtime).associate { it.capability to it.state }
 
-        runtimeCapabilities(module, runtime).forEach {
-            assertEquals(CapabilityState.MISSING_SCOPE, it.state)
-        }
+        assertEquals(CapabilityState.OBSERVED, states[RuntimeCapability.FILTERING])
+        assertEquals(CapabilityState.MISSING_SCOPE, states[RuntimeCapability.ORDERING])
+        assertEquals(CapabilityState.OBSERVED, states[RuntimeCapability.PACKAGE_VISIBILITY])
+    }
+
+    @Test
+    fun missingSystemScopeDoesNotPoisonResolverOrdering() {
+        val module = healthyModule().copy(grantedScope = setOf("com.android.intentresolver"))
+        val runtime = RuntimeStatus(ready = true, queryHits = 9, orderingHits = 9, visibilityHits = 9)
+        val states = runtimeCapabilities(module, runtime).associate { it.capability to it.state }
+
+        assertEquals(CapabilityState.MISSING_SCOPE, states[RuntimeCapability.FILTERING])
+        assertEquals(CapabilityState.OBSERVED, states[RuntimeCapability.ORDERING])
+        assertEquals(CapabilityState.MISSING_SCOPE, states[RuntimeCapability.PACKAGE_VISIBILITY])
+    }
+
+    @Test
+    fun staleResolverOnlyAffectsOrdering() {
+        val staleResolver = RunningTargetStatus(
+            "com.android.intentresolver",
+            "STALE",
+            BuildConfig.VERSION_CODE.toLong() - 1
+        )
+        val module = healthyModule().copy(
+            runningTargets = listOf(currentTarget("system"), staleResolver)
+        )
+        val runtime = RuntimeStatus(ready = true, queryHits = 3, orderingHits = 3, visibilityHits = 3)
+        val states = runtimeCapabilities(module, runtime).associate { it.capability to it.state }
+
+        assertEquals(CapabilityState.OBSERVED, states[RuntimeCapability.FILTERING])
+        assertEquals(CapabilityState.OUTDATED, states[RuntimeCapability.ORDERING])
+        assertEquals(CapabilityState.OBSERVED, states[RuntimeCapability.PACKAGE_VISIBILITY])
+    }
+
+    @Test
+    fun absentResolverHostIsNotReportedAsLoaded() {
+        val module = healthyModule().copy(
+            grantedScope = setOf("system"),
+            runningTargets = listOf(currentTarget("system")),
+            detection = ScopeDetection(hosts = listOf(systemHost))
+        )
+        val states = runtimeCapabilities(module, RuntimeStatus(ready = true))
+            .associate { it.capability to it.state }
+
+        assertEquals(CapabilityState.LOADED_UNOBSERVED, states[RuntimeCapability.FILTERING])
+        assertEquals(CapabilityState.NOT_READY, states[RuntimeCapability.ORDERING])
+        assertEquals(CapabilityState.LOADED_UNOBSERVED, states[RuntimeCapability.PACKAGE_VISIBILITY])
     }
 }


### PR DESCRIPTION
Fixes the full-source audit findings without changing resolver/root feature semantics:

- evaluate filtering, ordering and package-visibility capability state against their own scopes/targets
- restore/import persisted configuration with one SharedPreferences transaction and one revision
- bind scope/hot-reload UI publication to per-operation generations
- cache Resolver scope detection between explicit refreshes
- centralize strict package-name validation
- add regression tests for service-session races, capability isolation and package validation

Debug and release CI should validate compilation and unit tests before merge.