### PR TITLE
Optimize catalog, sync and root performance

### DIFF
--- a/app/src/main/java/com/yagay/ListCleaner/ListCleanerApp.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ListCleanerApp.kt
@@ -55,6 +55,8 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
     private val json = Json { ignoreUnknownKeys = true }
     private var pendingRecovery: ModuleConfig? = null
     private var corruptRecovery = false
+    private var acknowledgedSessionGeneration = -1L
+    private var acknowledgedRevision = -1L
 
     override fun onCreate() {
         super.onCreate()
@@ -75,6 +77,8 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
 
     override fun onServiceBind(service: XposedService) {
         val session = sessionRegistry.bind(service)
+        acknowledgedSessionGeneration = -1L
+        acknowledgedRevision = -1L
         this.service.value = service
         serviceSession.value = session
     }
@@ -82,6 +86,8 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
     override fun onServiceDied(service: XposedService) {
         val cleared = sessionRegistry.clear(service) ?: return
         if (serviceSession.value?.generation == cleared.generation) {
+            acknowledgedSessionGeneration = -1L
+            acknowledgedRevision = -1L
             serviceSession.value = null
             this.service.value = null
             publish(RuntimeStatus(message = getString(R.string.runtime_connection_lost)))
@@ -173,20 +179,8 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                 check(bound.apiVersion >= 102) { getString(R.string.runtime_framework_api_required) }
                 val targets = bound.runningTargets
                 check(isCurrent(session)) { getString(R.string.runtime_connection_changed) }
-                val config = rules.remoteSnapshot()
-                val encoded = json.encodeToString(ModuleConfig.serializer(), config)
-                require(encoded.length <= RuleRepository.MAX_BACKUP_CHARS) {
-                    getString(R.string.runtime_config_transfer_too_large)
-                }
-                val digest = RuntimeProtocol.digest(encoded)
-                val canPause = config.mode == DisplayMode.SHOW_ALL && targets.isNotEmpty() && targets.all {
+                val canPauseTargets = targets.isNotEmpty() && targets.all {
                     RuntimeProtocol.supportsSafetyPause(it.state.name, it.loadedVersionCode)
-                }
-                if (canPause && prefs.getString(RuleRepository.KEY_CONFIG, null) != encoded) {
-                    check(prefs.edit().putString(RuleRepository.KEY_CONFIG, encoded).commit()) {
-                        getString(R.string.runtime_pause_write_failed)
-                    }
-                    publishFor(session, RuntimeStatus(message = getString(R.string.runtime_pause_submitted)))
                 }
                 val incompatible = targets.filter {
                     !RuntimeProtocol.current(
@@ -200,7 +194,7 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                         "${target.processName} ${target.state.name}/v${target.loadedVersionCode}"
                     }
                     val suffix = getString(
-                        if (canPause) R.string.runtime_incompatible_pause_pending
+                        if (canPauseTargets) R.string.runtime_incompatible_pause_pending
                         else R.string.runtime_incompatible_paused
                     )
                     getString(R.string.runtime_incompatible_targets, details, suffix)
@@ -208,10 +202,31 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                 check(targets.any { it.processName == "system" }) {
                     getString(R.string.runtime_system_target_missing)
                 }
+
+                val revision = rules.revision.value
+                if (runtime.value.ready && acknowledgedSessionGeneration == session.generation &&
+                    acknowledgedRevision == revision) {
+                    return@withLock true
+                }
+
+                val config = rules.remoteSnapshot()
+                val encoded = json.encodeToString(ModuleConfig.serializer(), config)
+                require(encoded.length <= RuleRepository.MAX_BACKUP_CHARS) {
+                    getString(R.string.runtime_config_transfer_too_large)
+                }
+                val digest = RuntimeProtocol.digest(encoded)
+                val canPause = config.mode == DisplayMode.SHOW_ALL && canPauseTargets
+                val remoteEncoded = prefs.getString(RuleRepository.KEY_CONFIG, null)
+                if (canPause && remoteEncoded != encoded) {
+                    check(prefs.edit().putString(RuleRepository.KEY_CONFIG, encoded).commit()) {
+                        getString(R.string.runtime_pause_write_failed)
+                    }
+                    publishFor(session, RuntimeStatus(message = getString(R.string.runtime_pause_submitted)))
+                }
                 if (runtime.value.digest != digest) {
                     publishFor(session, RuntimeStatus(message = getString(R.string.runtime_waiting_ack)))
                 }
-                if (prefs.getString(RuleRepository.KEY_CONFIG, null) != encoded) {
+                if (remoteEncoded != encoded) {
                     check(prefs.edit().putString(RuleRepository.KEY_CONFIG, encoded).commit()) {
                         getString(R.string.runtime_remote_write_failed)
                     }
@@ -249,8 +264,8 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                 }
                 check(isCurrent(session)) { getString(R.string.runtime_connection_changed) }
                 check(acknowledged) { getString(R.string.runtime_ack_missing) }
-                check(rules.remoteSnapshot() == config) { getString(R.string.runtime_config_changed) }
-                publishFor(
+                check(rules.revision.value == revision) { getString(R.string.runtime_config_changed) }
+                val published = publishFor(
                     session,
                     RuntimeStatus(
                         ready = true,
@@ -261,6 +276,11 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                         orderingHits = orderingHits
                     )
                 )
+                if (published) {
+                    acknowledgedSessionGeneration = session.generation
+                    acknowledgedRevision = revision
+                }
+                published
             } catch (cancelled: CancellationException) {
                 throw cancelled
             } catch (failure: Exception) {
@@ -268,6 +288,8 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                 if (attemptSession != null && !isCurrent(attemptSession)) {
                     false
                 } else {
+                    acknowledgedSessionGeneration = -1L
+                    acknowledgedRevision = -1L
                     publish(RuntimeStatus(message = getString(R.string.runtime_validation_failed)))
                 }
             }
@@ -286,6 +308,8 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
             )
             pendingRecovery = null
             corruptRecovery = false
+            acknowledgedSessionGeneration = -1L
+            acknowledgedRevision = -1L
             publish(
                 RuntimeStatus(
                     message = getString(

--- a/app/src/main/java/com/yagay/ListCleaner/ListCleanerApp.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ListCleanerApp.kt
@@ -179,7 +179,7 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                 check(bound.apiVersion >= 102) { getString(R.string.runtime_framework_api_required) }
                 val targets = bound.runningTargets
                 check(isCurrent(session)) { getString(R.string.runtime_connection_changed) }
-                val canPauseTargets = targets.isNotEmpty() && targets.all {
+                val canPauseTargets = rules.displayMode.value == DisplayMode.SHOW_ALL && targets.isNotEmpty() && targets.all {
                     RuntimeProtocol.supportsSafetyPause(it.state.name, it.loadedVersionCode)
                 }
                 val incompatible = targets.filter {
@@ -215,7 +215,9 @@ class ListCleanerApp : Application(), XposedServiceHelper.OnServiceListener {
                     getString(R.string.runtime_config_transfer_too_large)
                 }
                 val digest = RuntimeProtocol.digest(encoded)
-                val canPause = config.mode == DisplayMode.SHOW_ALL && canPauseTargets
+                val canPause = config.mode == DisplayMode.SHOW_ALL && targets.isNotEmpty() && targets.all {
+                    RuntimeProtocol.supportsSafetyPause(it.state.name, it.loadedVersionCode)
+                }
                 val remoteEncoded = prefs.getString(RuleRepository.KEY_CONFIG, null)
                 if (canPause && remoteEncoded != encoded) {
                     check(prefs.edit().putString(RuleRepository.KEY_CONFIG, encoded).commit()) {

--- a/app/src/main/java/com/yagay/ListCleaner/data/IntentCatalog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/IntentCatalog.kt
@@ -52,6 +52,7 @@ class IntentCatalog(private val context: Context) {
     private val appIconCache = LruCache<String, Bitmap>(192)
     @Volatile private var cachedDefinitionFingerprint: String? = null
     @Volatile private var invalidated = true
+    @Volatile private var cacheHitsSinceLastScan = 0L
     @Volatile var lastReport: String = "Not scanned"
         private set
     @Volatile var lastFileReport: String = "No real-file probe"
@@ -77,13 +78,18 @@ class IntentCatalog(private val context: Context) {
             .joinToString("|") { (preset, definition) -> "$preset=$definition" }
         val cached = mutableCandidates.value
         if (!force && !invalidated && cached.isNotEmpty() && fingerprint == cachedDefinitionFingerprint) {
-            lastReport = "cacheHitAt=${Instant.now()} unique=${cached.size} customOpenTypes=${customDefinitions.size}\n" + lastReport
+            cacheHitsSinceLastScan++
             return@withContext cached
         }
 
+        val previousCacheHits = cacheHitsSinceLastScan
+        cacheHitsSinceLastScan = 0L
         val found = mutableListOf<ComponentCandidate>()
         val known = mutableSetOf<String>()
-        val report = StringBuilder("startedAt=${Instant.now()}\nmanagerUid=${android.os.Process.myUid()}\ncustomOpenTypes=${customDefinitions.size}\n")
+        val report = StringBuilder(
+            "startedAt=${Instant.now()}\nmanagerUid=${android.os.Process.myUid()}\n" +
+                "customOpenTypes=${customDefinitions.size}\ncacheHitsSincePreviousScan=$previousCacheHits\n"
+        )
         for (scheme in listOf("http", "https")) {
             val web = Intent(Intent.ACTION_VIEW, Uri.parse("$scheme://example.com")).addCategory(Intent.CATEGORY_BROWSABLE)
             runCatching {

--- a/app/src/main/java/com/yagay/ListCleaner/data/IntentCatalog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/IntentCatalog.kt
@@ -49,7 +49,9 @@ class IntentCatalog(private val context: Context) {
         }
     }
 
-    private val appIconCache = LruCache<String, Bitmap>(128)
+    private val appIconCache = LruCache<String, Bitmap>(192)
+    @Volatile private var cachedDefinitionFingerprint: String? = null
+    @Volatile private var invalidated = true
     @Volatile var lastReport: String = "Not scanned"
         private set
     @Volatile var lastFileReport: String = "No real-file probe"
@@ -60,8 +62,25 @@ class IntentCatalog(private val context: Context) {
     private data class Probe(val intent: Intent, val broad: Boolean, val label: String)
     private data class QueryResult(val candidates: List<ComponentCandidate>, val raw: Int, val flags: Int = 0)
 
-    suspend fun scan(customDefinitions: Map<OpenPreset, CustomOpenDefinition> = emptyMap()): List<ComponentCandidate> = withContext(Dispatchers.IO) {
-        appIconCache.evictAll()
+    /** Mark candidate discovery stale while keeping reusable app icons in memory. */
+    fun invalidate(packageName: String? = null) {
+        invalidated = true
+        packageName?.let(appIconCache::remove)
+    }
+
+    suspend fun scan(
+        customDefinitions: Map<OpenPreset, CustomOpenDefinition> = emptyMap(),
+        force: Boolean = false
+    ): List<ComponentCandidate> = withContext(Dispatchers.IO) {
+        val fingerprint = customDefinitions.entries
+            .sortedBy { it.key.ordinal }
+            .joinToString("|") { (preset, definition) -> "$preset=$definition" }
+        val cached = mutableCandidates.value
+        if (!force && !invalidated && cached.isNotEmpty() && fingerprint == cachedDefinitionFingerprint) {
+            lastReport = "cacheHitAt=${Instant.now()} unique=${cached.size} customOpenTypes=${customDefinitions.size}\n" + lastReport
+            return@withContext cached
+        }
+
         val found = mutableListOf<ComponentCandidate>()
         val known = mutableSetOf<String>()
         val report = StringBuilder("startedAt=${Instant.now()}\nmanagerUid=${android.os.Process.myUid()}\ncustomOpenTypes=${customDefinitions.size}\n")
@@ -91,14 +110,14 @@ class IntentCatalog(private val context: Context) {
                 report.appendLine("${probe.label} ERROR=${failure.javaClass.name}")
             }
         }
-        // PackageManager queries are blocking. Cancellation can arrive while the final query is
-        // running, so check once more before publishing shared catalog state.
         currentCoroutineContext().ensureActive()
         val result = merge(found)
         report.appendLine("finishedAt=${Instant.now()} unique=${result.size} failures=$failures")
         lastReport = report.toString()
         if (failures > 0) scanWarning = context.getString(R.string.catalog_partial_scan_failed, failures)
         mutableCandidates.value = result
+        cachedDefinitionFingerprint = fingerprint
+        invalidated = false
         result
     }
 

--- a/app/src/main/java/com/yagay/ListCleaner/data/RootComponentCatalog.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/data/RootComponentCatalog.kt
@@ -73,7 +73,6 @@ class RootComponentCatalog(private val context: Context) {
 
     @Suppress("DEPRECATION")
     fun scan(): RootComponentScan {
-        icons.evictAll()
         val errors = mutableListOf<String>()
         val items = CleanupKind.entries.flatMap { kind ->
             try {
@@ -85,6 +84,23 @@ class RootComponentCatalog(private val context: Context) {
             }
         }.sortedWith(compareBy({ it.owner.lowercase() }, { it.label.lowercase() }, { it.id }))
         return RootComponentScan(items, errors.joinToString("\n"), System.currentTimeMillis())
+    }
+
+    /** Refresh only components just mutated; avoids re-querying every tile/shortcut/widget provider. */
+    fun refreshItems(previous: RootComponentScan, targets: Collection<RootComponent>): RootComponentScan {
+        if (targets.isEmpty() || previous.items.isEmpty()) return previous
+        val targetIds = targets.mapTo(hashSetOf()) { it.id }
+        val refreshed = previous.items.map { item ->
+            if (item.id !in targetIds) item else readCurrent(item) ?: item
+        }
+        return previous.copy(items = refreshed, observedAt = System.currentTimeMillis())
+    }
+
+    private fun readCurrent(target: RootComponent): RootComponent? {
+        val info = query(target.kind).firstOrNull {
+            ComponentName(it.packageName, it.name) == target.component
+        } ?: return null
+        return read(target.kind, info)
     }
 
     private fun read(kind: CleanupKind, info: ComponentInfo): RootComponent {

--- a/app/src/main/java/com/yagay/ListCleaner/domain/Rule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/domain/Rule.kt
@@ -47,10 +47,23 @@ data class ComponentCandidate(
     val broadMatch: Boolean = false
 ) {
     val isCatalogCandidate: Boolean get() = !unavailable && !restricted
+    val normalizedAppLabel: String by lazy(LazyThreadSafetyMode.NONE) { appLabel.lowercase() }
+    private val normalizedSearch: String by lazy(LazyThreadSafetyMode.NONE) {
+        buildString(appLabel.length + activityLabel.length + rule.packageName.length + rule.className.length + 3) {
+            append(appLabel.lowercase())
+            append('\u0000')
+            append(activityLabel.lowercase())
+            append('\u0000')
+            append(rule.packageName.lowercase())
+            append('\u0000')
+            append(rule.className.lowercase())
+        }
+    }
 
-    fun matchesQuery(query: String): Boolean = query.isBlank() ||
-        appLabel.contains(query, true) || activityLabel.contains(query, true) ||
-        rule.packageName.contains(query, true) || rule.className.contains(query, true)
+    fun matchesQuery(query: String): Boolean {
+        val needle = query.trim()
+        return needle.isEmpty() || normalizedSearch.contains(needle.lowercase())
+    }
 }
 
 @Serializable

--- a/app/src/main/java/com/yagay/ListCleaner/ui/AppScopePicker.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/AppScopePicker.kt
@@ -3,6 +3,7 @@ package com.yagay.ListCleaner.ui
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.util.LruCache
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -23,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.graphics.drawable.toBitmap
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.yagay.ListCleaner.ListCleanerApp
 import com.yagay.ListCleaner.R
 import com.yagay.ListCleaner.domain.VisibilityScope
@@ -33,8 +35,13 @@ data class ScopeAppEntry(
     val packageName: String,
     val label: String,
     val system: Boolean,
-    val icon: Bitmap?,
+    val normalizedLabel: String = label.lowercase(),
+    val normalizedPackage: String = packageName.lowercase(),
 )
+
+private object ScopeIconCache {
+    val icons = LruCache<String, Bitmap>(128)
+}
 
 @Suppress("DEPRECATION")
 private fun loadScopeApps(pm: PackageManager, selfPackage: String): List<ScopeAppEntry> {
@@ -51,12 +58,27 @@ private fun loadScopeApps(pm: PackageManager, selfPackage: String): List<ScopeAp
                 label = runCatching { pm.getApplicationLabel(info).toString() }.getOrDefault(info.packageName),
                 system = (info.flags and ApplicationInfo.FLAG_SYSTEM) != 0 ||
                     (info.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0,
-                icon = runCatching { pm.getApplicationIcon(info).toBitmap(64, 64) }.getOrNull(),
             )
         }
         .distinctBy { it.packageName }
-        .sortedWith(compareBy<ScopeAppEntry> { it.label.lowercase() }.thenBy { it.packageName })
+        .sortedWith(compareBy<ScopeAppEntry> { it.normalizedLabel }.thenBy { it.packageName })
         .toList()
+}
+
+@Composable
+private fun scopeAppIcon(packageName: String): Bitmap? {
+    val context = LocalContext.current
+    val cached = remember(packageName) { ScopeIconCache.icons.get(packageName) }
+    val icon by produceState<Bitmap?>(initialValue = cached, packageName) {
+        if (value == null) {
+            value = withContext(Dispatchers.IO) {
+                runCatching {
+                    context.packageManager.getApplicationIcon(packageName).toBitmap(64, 64)
+                }.getOrNull()?.also { ScopeIconCache.icons.put(packageName, it) }
+            }
+        }
+    }
+    return icon
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -68,8 +90,8 @@ internal fun AppScopePickerDialog(
 ) {
     val context = LocalContext.current
     val app = context.applicationContext as ListCleanerApp
-    val visibilityScopes by app.rules.visibilityScopes.collectAsState()
-    val fullPackages by app.rules.visibilityFullPackages.collectAsState()
+    val visibilityScopes by app.rules.visibilityScopes.collectAsStateWithLifecycle()
+    val fullPackages by app.rules.visibilityFullPackages.collectAsStateWithLifecycle()
     var query by remember { mutableStateOf("") }
     var showSystem by remember { mutableStateOf(true) }
     var apps by remember { mutableStateOf<List<ScopeAppEntry>>(emptyList()) }
@@ -84,10 +106,10 @@ internal fun AppScopePickerDialog(
         val needle = query.trim().lowercase()
         apps.filter { entry ->
             (showSystem || !entry.system) &&
-                (needle.isEmpty() || entry.label.lowercase().contains(needle) || entry.packageName.lowercase().contains(needle))
+                (needle.isEmpty() || entry.normalizedLabel.contains(needle) || entry.normalizedPackage.contains(needle))
         }.sortedWith(
             compareBy<ScopeAppEntry> { if (it.packageName in selected) 0 else 1 }
-                .thenBy { it.label.lowercase() }
+                .thenBy { it.normalizedLabel }
                 .thenBy { it.packageName }
         )
     }
@@ -170,15 +192,16 @@ internal fun AppScopePickerDialog(
                     LazyColumn(Modifier.fillMaxSize()) {
                         items(visible, key = { it.packageName }) { entry ->
                             val checked = entry.packageName in selected
+                            val bitmap = scopeAppIcon(entry.packageName)
                             Row(
                                 Modifier.fillMaxWidth().clickable {
                                     onSelectedChange(if (checked) selected - entry.packageName else selected + entry.packageName)
                                 }.padding(vertical = 8.dp),
                                 verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                entry.icon?.let { bitmap ->
+                                bitmap?.let {
                                     Image(
-                                        bitmap = bitmap.asImageBitmap(),
+                                        bitmap = it.asImageBitmap(),
                                         contentDescription = null,
                                         modifier = Modifier.size(40.dp),
                                     )

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainActivity.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainActivity.kt
@@ -122,7 +122,7 @@ class MainActivity : ComponentActivity() {
                     vm::setQuery,
                     { searchExpanded = true },
                     closeSearch,
-                    { if (state.destination == Destination.TILES) vm.refreshComponents() else vm.refresh() },
+                    { if (state.destination == Destination.TILES) vm.refreshComponents() else vm.refresh(forceCatalog = true) },
                     { restore.launch(arrayOf("application/json", "text/plain")) },
                     { export.launch("ListCleaner-backup.json") }
                 )

--- a/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/MainViewModel.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -91,14 +93,25 @@ private fun appSelectionRank(group: AppGroup, selected: Set<ComponentRule>): Int
     }
 }
 
-fun groupCandidates(
-    candidates: List<ComponentCandidate>,
+private fun baseAppGroups(candidates: List<ComponentCandidate>): List<AppGroup> =
+    candidates.groupBy { it.rule.packageName }.map { (_, all) ->
+        val first = all.first()
+        AppGroup(
+            first.rule.packageName,
+            first.appLabel,
+            first.appIcon,
+            all.sortedBy { it.rule.kind.ordinal }
+        )
+    }
+
+private fun filterAppGroups(
+    groups: List<AppGroup>,
     selected: Set<ComponentRule>,
     filter: IntentKind?,
     query: String,
     uiFilter: UiFilter
-): List<AppGroup> = candidates.groupBy { it.rule.packageName }.mapNotNull { (_, all) ->
-    val matching = all.filter {
+): List<AppGroup> = groups.mapNotNull { group ->
+    val matching = group.components.filter {
         val isSelected = it.rule in selected
         val matchesUiFilter = when (uiFilter) {
             UiFilter.ALL -> true
@@ -107,18 +120,21 @@ fun groupCandidates(
         }
         catalogVisible(it, isSelected, uiFilter) && matchesUiFilter &&
             (filter == null || it.rule.kind == filter) && it.matchesQuery(query)
-    }.sortedBy { it.rule.kind.ordinal }
-    if (matching.isEmpty()) null else AppGroup(
-        all.first().rule.packageName,
-        all.first().appLabel,
-        all.first().appIcon,
-        matching
-    )
+    }
+    if (matching.isEmpty()) null else group.copy(components = matching)
 }.sortedWith(
     compareBy<AppGroup> { appSelectionRank(it, selected) }
-        .thenBy { it.appLabel.lowercase() }
+        .thenBy { it.components.firstOrNull()?.normalizedAppLabel ?: it.appLabel.lowercase() }
         .thenBy { it.packageName }
 )
+
+fun groupCandidates(
+    candidates: List<ComponentCandidate>,
+    selected: Set<ComponentRule>,
+    filter: IntentKind?,
+    query: String,
+    uiFilter: UiFilter
+): List<AppGroup> = filterAppGroups(baseAppGroups(candidates), selected, filter, query, uiFilter)
 
 fun retainConfiguredCandidates(
     items: List<ComponentCandidate>,
@@ -236,6 +252,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val error = MutableStateFlow<String?>(null)
     private val filter = MutableStateFlow<IntentKind?>(null)
     private val query = MutableStateFlow("")
+    @OptIn(kotlinx.coroutines.FlowPreview::class)
+    private val debouncedQuery = query.debounce(120).distinctUntilChanged()
     private val uiFilter = MutableStateFlow(UiFilter.ALL)
     private val moduleStatus: StateFlow<ModuleStatus> = moduleRuntime.status
     private val destination = MutableStateFlow(Destination.RULES)
@@ -295,27 +313,45 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    private data class PreparedCandidates(
+        val candidates: List<ComponentCandidate>,
+        val selected: Set<ComponentRule>,
+        val groups: List<AppGroup>
+    )
+
     private data class ListContent(
         val candidates: List<ComponentCandidate>,
         val filter: IntentKind?,
-        val query: String,
         val groups: List<AppGroup>,
         val selected: Set<ComponentRule> = emptySet(),
         val uiFilter: UiFilter = UiFilter.ALL
     )
 
-    private val grouped = combine(candidates, app.rules.rules, filter, query, uiFilter) {
-        scanned, selected, kind, text, ui ->
+    private val preparedCandidates = combine(candidates, app.rules.rules) { scanned, selected ->
         val items = retainConfiguredCandidates(
             scanned,
             selected,
             app.getString(R.string.candidate_configured_not_observed)
         )
-        ListContent(items, kind, text, groupCandidates(items, selected, kind, text, ui), selected, ui)
+        PreparedCandidates(items, selected, baseAppGroups(items))
     }.stateIn(
         viewModelScope,
         SharingStarted.WhileSubscribed(5_000),
-        ListContent(emptyList(), null, "", emptyList())
+        PreparedCandidates(emptyList(), emptySet(), emptyList())
+    )
+
+    private val grouped = combine(preparedCandidates, filter, debouncedQuery, uiFilter) { prepared, kind, text, ui ->
+        ListContent(
+            prepared.candidates,
+            kind,
+            filterAppGroups(prepared.groups, prepared.selected, kind, text, ui),
+            prepared.selected,
+            ui
+        )
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        ListContent(emptyList(), null, emptyList())
     )
 
     val state: StateFlow<MainState> = combine(
@@ -331,7 +367,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         destination,
         expandedAppKey,
         app.rules.hiddenFromApps,
-        app.rules.openTypes
+        app.rules.openTypes,
+        query
     ) { values ->
         @Suppress("UNCHECKED_CAST")
         val content = values[3] as ListContent
@@ -346,7 +383,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             runtime = values[4] as RuntimeStatus,
             displayMode = values[5] as DisplayMode,
             filter = content.filter,
-            query = content.query,
+            query = values[13] as String,
             priorities = priorityConfig,
             groups = content.groups,
             diagnosticMode = values[7] as Boolean,
@@ -385,7 +422,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         refresh()
     }
 
-    fun refresh() {
+    fun refresh(forceCatalog: Boolean = false) {
         val generation = ++refreshGeneration
         refreshJob?.cancel()
         refreshJob = viewModelScope.launch {
@@ -397,7 +434,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 candidates.value = app.catalog.completeConfigured(candidates.value, configured)
                 check(app.synchronize()) { app.runtime.value.message }
                 val session = app.currentSession()
-                val result = app.catalog.scan(app.rules.openTypes.value.customDefinitions)
+                val result = app.catalog.scan(app.rules.openTypes.value.customDefinitions, force = forceCatalog)
                 check(app.isCurrent(session)) { app.getString(R.string.runtime_connection_changed) }
                 check(app.synchronize()) { app.runtime.value.message }
                 if (generation == refreshGeneration && app.isCurrent(session)) {

--- a/app/src/main/java/com/yagay/ListCleaner/ui/RootComponentsController.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/ui/RootComponentsController.kt
@@ -85,48 +85,46 @@ internal class RootComponentsController(
         mutableMessage.value = app.getString(R.string.root_requesting_verify)
         scope.launch {
             withContext(Dispatchers.IO) {
-                var completed = 0
-                var operationStarted = false
+                val completedTargets = mutableListOf<RootComponent>()
                 try {
                     catalog.requireRoot()
                     var result = ""
                     for (target in targets) {
                         coroutineContext.ensureActive()
-                        operationStarted = true
                         mutableMessage.value = app.getString(
                             if (enable) R.string.root_progress_enable else R.string.root_progress_disable,
-                            completed + 1,
+                            completedTargets.size + 1,
                             targets.size,
                             target.label
                         )
                         result = withContext(NonCancellable) { catalog.change(target, enable) }
-                        completed++
+                        completedTargets += target
                     }
                     mutableMessage.value = if (targets.size == 1) {
                         result
                     } else {
                         app.getString(
                             if (enable) R.string.root_batch_enabled else R.string.root_batch_disabled,
-                            completed
+                            completedTargets.size
                         )
                     }
                 } catch (cancelled: CancellationException) {
-                    Log.i(TAG, "Root component batch cancelled after $completed/${targets.size}")
+                    Log.i(TAG, "Root component batch cancelled after ${completedTargets.size}/${targets.size}")
                     throw cancelled
                 } catch (failure: ComponentRootCommand.RootAccessException) {
                     val message = rootAccessMessage(failure)
                     mutableMessage.value = message
                     mutableRootNotice.value = message
                 } catch (failure: Exception) {
-                    Log.e(TAG, "Root component mutation failed after $completed/${targets.size}", failure)
+                    Log.e(TAG, "Root component mutation failed after ${completedTargets.size}/${targets.size}", failure)
                     mutableMessage.value = app.getString(
                         R.string.root_batch_stopped,
-                        completed,
+                        completedTargets.size,
                         targets.size,
                         app.getString(R.string.root_operation_not_allowed)
                     )
                 } finally {
-                    if (operationStarted) refreshAfterMutation()
+                    if (completedTargets.isNotEmpty()) refreshAfterMutation(completedTargets)
                     mutableBusy.value = false
                 }
             }
@@ -144,53 +142,52 @@ internal class RootComponentsController(
         mutableMessage.value = app.getString(R.string.root_requesting_invert)
         scope.launch {
             withContext(Dispatchers.IO) {
-                var completed = 0
-                var operationStarted = false
+                val completedTargets = mutableListOf<RootComponent>()
                 try {
                     catalog.requireRoot()
                     for (target in targets) {
                         coroutineContext.ensureActive()
-                        operationStarted = true
                         mutableMessage.value = app.getString(
                             R.string.root_progress_invert,
-                            completed + 1,
+                            completedTargets.size + 1,
                             targets.size,
                             target.label
                         )
                         withContext(NonCancellable) { catalog.change(target, target.enabled == false) }
-                        completed++
+                        completedTargets += target
                     }
-                    mutableMessage.value = app.getString(R.string.root_batch_inverted, completed)
+                    mutableMessage.value = app.getString(R.string.root_batch_inverted, completedTargets.size)
                 } catch (cancelled: CancellationException) {
-                    Log.i(TAG, "Root component inversion cancelled after $completed/${targets.size}")
+                    Log.i(TAG, "Root component inversion cancelled after ${completedTargets.size}/${targets.size}")
                     throw cancelled
                 } catch (failure: ComponentRootCommand.RootAccessException) {
                     val message = rootAccessMessage(failure)
                     mutableMessage.value = message
                     mutableRootNotice.value = message
                 } catch (failure: Exception) {
-                    Log.e(TAG, "Root component inversion failed after $completed/${targets.size}", failure)
+                    Log.e(TAG, "Root component inversion failed after ${completedTargets.size}/${targets.size}", failure)
                     mutableMessage.value = app.getString(
                         R.string.root_invert_stopped,
-                        completed,
+                        completedTargets.size,
                         targets.size,
                         app.getString(R.string.root_operation_not_allowed)
                     )
                 } finally {
-                    if (operationStarted) refreshAfterMutation()
+                    if (completedTargets.isNotEmpty()) refreshAfterMutation(completedTargets)
                     mutableBusy.value = false
                 }
             }
         }
     }
 
-    private fun refreshAfterMutation() {
-        runCatching { catalog.scan() }
+    private fun refreshAfterMutation(targets: List<RootComponent>) {
+        runCatching { catalog.refreshItems(mutableScan.value, targets) }
             .onSuccess { mutableScan.value = it }
             .onFailure { failure ->
-                Log.e(TAG, "Post-mutation Root component scan failed", failure)
-                mutableScan.value = RootComponentScan(
-                    warning = app.getString(R.string.root_post_scan_failed)
+                Log.e(TAG, "Post-mutation Root component refresh failed", failure)
+                mutableScan.value = mutableScan.value.copy(
+                    warning = app.getString(R.string.root_post_scan_failed),
+                    observedAt = System.currentTimeMillis()
                 )
             }
     }

--- a/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
+++ b/app/src/main/java/com/yagay/ListCleaner/xposed/ListCleanerModule.kt
@@ -39,6 +39,7 @@ import com.yagay.ListCleaner.domain.VisibilityLayout
 import com.yagay.ListCleaner.domain.VisibilitySignature
 import kotlinx.serialization.json.Json
 import java.lang.reflect.Constructor
+import java.lang.reflect.Field
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
@@ -74,6 +75,9 @@ class ListCleanerModule : XposedModule() {
     }
 
     private data class ListResult(val values: List<*>, val rebuild: (List<*>) -> Any?)
+    private data class MethodAccessor(val method: Method?)
+    private data class PackageNameAccessor(val getter: Method?, val field: Field?)
+    private data class ParceledListAccessor(val getList: Method, val constructor: Constructor<*>)
 
     @Volatile
     private var snapshot = RuleSnapshot(emptySet(), DisplayMode.HIDE_SELECTED, PriorityConfig(), DefaultOpenConfig(), OpenTypeConfig(), false)
@@ -93,6 +97,10 @@ class ListCleanerModule : XposedModule() {
     private val queryHits = AtomicLong()
     private val visibilityHits = AtomicLong()
     private val orderingHits = AtomicLong()
+    private val packagesForUidCache = ConcurrentHashMap<Class<*>, MethodAccessor>()
+    private val packageNameAccessorCache = ConcurrentHashMap<Class<*>, PackageNameAccessor>()
+    private val callerPackageFieldsCache = ConcurrentHashMap<Class<*>, List<Field>>()
+    private val parceledListAccessorCache = ConcurrentHashMap<Class<*>, ParceledListAccessor>()
     private val preferences by lazy(LazyThreadSafetyMode.PUBLICATION) {
         getRemotePreferences(RuleRepository.REMOTE_PREFS)
     }
@@ -207,7 +215,7 @@ class ListCleanerModule : XposedModule() {
     @Synchronized private fun pollPreferences() {
         val now = SystemClock.elapsedRealtime()
         if (now < nextPreferencePoll) return
-        nextPreferencePoll = now + 2_000
+        nextPreferencePoll = now + if (listenerRegistered) 10_000 else 2_000
         refreshRulesSafely("query poll")
     }
 
@@ -325,44 +333,49 @@ class ListCleanerModule : XposedModule() {
     private fun packageNamesFromCallerSetting(value: Any?): Set<String> {
         if (value == null) return emptySet()
         packageNameFromState(value)?.let { return setOf(it) }
-        val classes = generateSequence(value.javaClass as Class<*>?) { it.superclass }.toList()
         val result = linkedSetOf<String>()
-        classes.asSequence().flatMap { it.declaredFields.asSequence() }
-            .filter { field ->
-                val name = field.name.lowercase()
-                "package" in name || "packages" in name
-            }.take(12).forEach { field ->
-                runCatching {
-                    field.isAccessible = true
-                    when (val nested = field.get(value)) {
-                        is Array<*> -> nested.asSequence()
-                        is Collection<*> -> nested.asSequence()
-                        is Map<*, *> -> nested.values.asSequence()
-                        else -> emptySequence()
-                    }.mapNotNull(::packageNameFromState).forEach(result::add)
-                }
+        callerPackageFields(value.javaClass).forEach { field ->
+            runCatching {
+                when (val nested = field.get(value)) {
+                    is Array<*> -> nested.asSequence()
+                    is Collection<*> -> nested.asSequence()
+                    is Map<*, *> -> nested.values.asSequence()
+                    else -> emptySequence()
+                }.mapNotNull(::packageNameFromState).forEach(result::add)
             }
+        }
         return result
     }
 
-    private fun hasGetPackagesForUid(clazz: Class<*>): Boolean =
-        generateSequence(clazz as Class<*>?) { it.superclass }.any { current ->
-            current.declaredMethods.any { method ->
-                method.name == "getPackagesForUid" && method.parameterTypes.size == 1 &&
-                    method.parameterTypes[0] == Int::class.javaPrimitiveType
+    private fun callerPackageFields(clazz: Class<*>): List<Field> = callerPackageFieldsCache.computeIfAbsent(clazz) {
+        generateSequence(clazz as Class<*>?) { it.superclass }
+            .flatMap { it.declaredFields.asSequence() }
+            .filter { field ->
+                val name = field.name.lowercase()
+                "package" in name || "packages" in name
             }
-        }
+            .take(12)
+            .onEach { it.isAccessible = true }
+            .toList()
+    }
+
+    private fun packagesForUidMethod(clazz: Class<*>): Method? = packagesForUidCache.computeIfAbsent(clazz) {
+        MethodAccessor(
+            generateSequence(clazz as Class<*>?) { it.superclass }
+                .flatMap { it.declaredMethods.asSequence() }
+                .firstOrNull { candidate ->
+                    candidate.name == "getPackagesForUid" && candidate.parameterTypes.size == 1 &&
+                        candidate.parameterTypes[0] == Int::class.javaPrimitiveType
+                }?.apply { isAccessible = true }
+        )
+    }.method
+
+    private fun hasGetPackagesForUid(clazz: Class<*>): Boolean = packagesForUidMethod(clazz) != null
 
     private fun packagesForUid(computer: Any, uid: Int): Set<String> {
-        val method = generateSequence(computer.javaClass as Class<*>?) { it.superclass }
-            .flatMap { it.declaredMethods.asSequence() }
-            .firstOrNull { candidate ->
-                candidate.name == "getPackagesForUid" && candidate.parameterTypes.size == 1 &&
-                    candidate.parameterTypes[0] == Int::class.javaPrimitiveType
-            } ?: return emptySet()
+        val method = packagesForUidMethod(computer.javaClass) ?: return emptySet()
         val identity = Binder.clearCallingIdentity()
         return try {
-            method.isAccessible = true
             when (val result = method.invoke(computer, uid)) {
                 is Array<*> -> result.filterIsInstance<String>().toSet()
                 is Collection<*> -> result.filterIsInstance<String>().toSet()
@@ -376,26 +389,28 @@ class ListCleanerModule : XposedModule() {
         }
     }
 
-    private fun packageNameFromState(value: Any?): String? {
-        if (value == null || value is Number || value is Boolean || value is ClassLoader) return null
-        if (value is String) return value.takeIf(::looksLikePackageName)
-
-        val classes = generateSequence(value.javaClass as Class<*>?) { it.superclass }.toList()
-        val getter = classes.asSequence().flatMap { it.declaredMethods.asSequence() }
+    private fun packageNameAccessor(clazz: Class<*>): PackageNameAccessor = packageNameAccessorCache.computeIfAbsent(clazz) {
+        val classes = generateSequence(clazz as Class<*>?) { it.superclass }.toList()
+        val getter = classes.asSequence().flatMap { current -> current.declaredMethods.asSequence() }
             .firstOrNull { method ->
                 method.parameterTypes.isEmpty() && method.returnType == String::class.java &&
                     method.name in setOf("getPackageName", "getName")
-            }
-        runCatching {
-            getter?.isAccessible = true
-            (getter?.invoke(value) as? String)?.takeIf(::looksLikePackageName)
-        }.getOrNull()?.let { return it }
-
-        val field = classes.asSequence().flatMap { it.declaredFields.asSequence() }
+            }?.apply { isAccessible = true }
+        val field = classes.asSequence().flatMap { current -> current.declaredFields.asSequence() }
             .firstOrNull { it.type == String::class.java && it.name in setOf("mName", "name", "packageName", "mPackageName") }
+            ?.apply { isAccessible = true }
+        PackageNameAccessor(getter, field)
+    }
+
+    private fun packageNameFromState(value: Any?): String? {
+        if (value == null || value is Number || value is Boolean || value is ClassLoader) return null
+        if (value is String) return value.takeIf(::looksLikePackageName)
+        val accessor = packageNameAccessor(value.javaClass)
+        runCatching {
+            (accessor.getter?.invoke(value) as? String)?.takeIf(::looksLikePackageName)
+        }.getOrNull()?.let { return it }
         return runCatching {
-            field?.isAccessible = true
-            (field?.get(value) as? String)?.takeIf(::looksLikePackageName)
+            (accessor.field?.get(value) as? String)?.takeIf(::looksLikePackageName)
         }.getOrNull()
     }
 
@@ -819,13 +834,13 @@ class ListCleanerModule : XposedModule() {
     }
 
     private fun extractParceledListSlice(original: Any): ListResult? {
-        val values = runCatching {
-            original.javaClass.getMethod("getList").invoke(original) as? List<*>
-        }.getOrNull() ?: return null
-        val constructor: Constructor<*> = runCatching {
-            original.javaClass.getDeclaredConstructor(List::class.java).apply { isAccessible = true }
-        }.getOrNull() ?: return null
-        return ListResult(values) { constructor.newInstance(it) }
+        val accessor = parceledListAccessorCache.computeIfAbsent(original.javaClass) { clazz ->
+            val getList = clazz.getMethod("getList").apply { isAccessible = true }
+            val constructor = clazz.getDeclaredConstructor(List::class.java).apply { isAccessible = true }
+            ParceledListAccessor(getList, constructor)
+        }
+        val values = runCatching { accessor.getList.invoke(original) as? List<*> }.getOrNull() ?: return null
+        return ListResult(values) { accessor.constructor.newInstance(it) }
     }
 
     @Synchronized private fun initializePreferences() {


### PR DESCRIPTION
Performance pass focused on low-risk hot paths without changing filtering/root semantics:

- cache system_server reflection accessors for getPackagesForUid, caller package fields, package-name accessors and ParceledListSlice reconstruction
- lengthen RemotePreferences fallback polling when the preference listener is healthy
- reuse intent catalog results when definitions are unchanged; manual refresh still forces a full scan
- retain intent/root app icon caches across scans
- lazy-load AppScopePicker icons only for visible rows
- skip redundant config serialization, hashing, remote writes and ACK probes for an already-confirmed session/revision while still validating running target versions
- use revision equality instead of constructing a second full ModuleConfig at the end of synchronization
- refresh only root components actually changed by a mutation instead of rescanning all tiles/shortcuts/widgets
- precompute candidate search normalization
- cache base app groups so query/filter changes no longer rerun groupBy over the whole catalog
- debounce list search filtering by 120 ms while keeping typed text immediate in UI state

Debug/unit-test and unsigned Release CI must both pass before merge.